### PR TITLE
feat: only sync certain libraries

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/history/HistoryTable.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/history/HistoryTable.tsx
@@ -35,11 +35,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useQueryParams } from "@/hooks/useQueryParams";
 import { Server, UserPlaybackStatistics } from "@/lib/db";
 import { formatDuration } from "@/lib/utils";
-import { useRouter } from "nextjs-toploader/app";
-import { useQueryParams } from "@/hooks/useQueryParams";
 import { useSearchParams } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useDebounce } from "use-debounce";
 
 export interface HistoryTableProps {
@@ -225,7 +225,7 @@ export function HistoryTable({
                 onClick={() => {
                   window.open(
                     `${server.url}/web/#/details?id=${playbackActivity.item_id}`,
-                    "_blank"
+                    "_blank",
                   );
                 }}
               >
@@ -234,7 +234,7 @@ export function HistoryTable({
               <DropdownMenuItem
                 onClick={() => {
                   router.push(
-                    `/servers/${server.id}/users/${playbackActivity.user_name}`
+                    `/servers/${server.id}/users/${playbackActivity.user_name}`,
                   );
                 }}
               >
@@ -248,7 +248,7 @@ export function HistoryTable({
   ];
 
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
+    [],
   );
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({
@@ -333,7 +333,7 @@ export function HistoryTable({
                         ? null
                         : flexRender(
                             header.column.columnDef.header,
-                            header.getContext()
+                            header.getContext(),
                           )}
                     </TableHead>
                   );
@@ -352,7 +352,7 @@ export function HistoryTable({
                     <TableCell key={cell.id}>
                       {flexRender(
                         cell.column.columnDef.cell,
-                        cell.getContext()
+                        cell.getContext(),
                       )}
                     </TableCell>
                   ))}

--- a/app/app/(app)/servers/[id]/(auth)/history/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/history/page.tsx
@@ -9,7 +9,7 @@ export default async function HistoryPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ page?: string;  }>;
+  searchParams: Promise<{ page?: string }>;
 }) {
   const { id } = await params;
   const { page } = await searchParams;

--- a/app/app/(app)/servers/[id]/(auth)/library/ItemWatchStatsTable.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/library/ItemWatchStatsTable.tsx
@@ -83,7 +83,7 @@ export function ItemWatchStatsTable({
   }, [debouncedSearch]);
 
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
+    [],
   );
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
@@ -213,7 +213,7 @@ export function ItemWatchStatsTable({
                 onClick={() => {
                   window.open(
                     `${server.url}/web/#/details?id=${playbackActivity.item_id}`,
-                    "_blank"
+                    "_blank",
                   );
                 }}
               >
@@ -293,7 +293,7 @@ export function ItemWatchStatsTable({
                         ? null
                         : flexRender(
                             header.column.columnDef.header,
-                            header.getContext()
+                            header.getContext(),
                           )}
                     </TableHead>
                   );
@@ -380,5 +380,5 @@ const MemoizedTableRow = React.memo(
   (prevProps, nextProps) => {
     // Only re-render if row data has changed
     return prevProps.row.original.item_id === nextProps.row.original.item_id;
-  }
+  },
 );

--- a/app/app/(app)/servers/[id]/(auth)/library/LibraryDropdown.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/library/LibraryDropdown.tsx
@@ -60,7 +60,7 @@ const LibraryDropdown = ({ libraries }: LibraryDropdownProps) => {
     const allSelected =
       newSelectedIds.length === libraries.length &&
       libraries.every((lib) =>
-        newSelectedIds.includes(Number.parseInt(lib.id))
+        newSelectedIds.includes(Number.parseInt(lib.id)),
       );
 
     // If no libraries are selected, remove the parameter (same as all selected)

--- a/app/app/(app)/servers/[id]/(auth)/library/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/library/page.tsx
@@ -53,7 +53,7 @@ export default async function DashboardPage({
     sort_by,
     type,
     search,
-    libraryIds
+    libraryIds,
   );
 
   return (

--- a/app/app/(app)/servers/[id]/(auth)/settings/DeleteServer.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/DeleteServer.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Server, deleteServer } from "@/lib/db";
-import { Loader2 } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -42,7 +41,7 @@ export const DeleteServer: React.FC<Props> = ({ server }) => {
   };
 
   return (
-    <div className="border p-4 rounded-lg flex flex-col gap-4 items-start">
+    <div className="border p-4 rounded-lg flex flex-col gap-4 items-start my-8">
       <p className="text-destructive">Danger area</p>
       <AlertDialog>
         <AlertDialogTrigger asChild>
@@ -53,7 +52,10 @@ export const DeleteServer: React.FC<Props> = ({ server }) => {
           <AlertDialogHeader>
             <AlertDialogDescription>
               This action cannot be undone. This will permanently delete the
-              server and remove all associated data.
+              server and remove all associated data from Streamyfin.
+              <br />
+              <br />
+              Note: this will not remove the server from Jellyfin.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/app/app/(app)/servers/[id]/(auth)/settings/LibrarySettings.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/LibrarySettings.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Spinner } from "@/components/Spinner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Library, Server, updateServer } from "@/lib/db";
+import { CollectionFolder } from "@/lib/jellyfin";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export default function LibrarySettings({
+  server,
+  libraries,
+}: {
+  server: Server;
+  libraries?: CollectionFolder[];
+}) {
+  const [selectedLibraries, setSelectedLibraries] = useState<string[]>(
+    server.enabled_libraries || []
+  );
+
+  const [loading, setLoading] = useState(false);
+
+  const handleLibraryToggle = (libraryId: string) => {
+    setSelectedLibraries((current) => {
+      if (current.includes(libraryId)) {
+        return current.filter((id) => id !== libraryId);
+      }
+      return [...current, libraryId];
+    });
+  };
+
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      await updateServer(server.id, {
+        enabled_libraries: selectedLibraries,
+      });
+      toast.success("Library settings updated successfully");
+    } catch (error) {
+      console.error("Error updating library settings:", error);
+      toast.error("Failed to update library settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Library Sync Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-4">Select the libraries you want to sync:</p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          {libraries?.map((library) => (
+            <div
+              key={library.Id}
+              className="flex items-center space-x-3 border p-4 rounded-md"
+            >
+              <Checkbox
+                id={`library-${library.Id}`}
+                checked={selectedLibraries.includes(library.Id)}
+                onCheckedChange={() => handleLibraryToggle(library.Id)}
+              />
+              <label
+                htmlFor={`library-${library.Id}`}
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                {library.Name}
+              </label>
+            </div>
+          ))}
+        </div>
+        <Button onClick={handleSave} disabled={loading}>
+          {loading ? <Spinner /> : "Save Settings"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/app/(app)/servers/[id]/(auth)/settings/Tasks.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/Tasks.tsx
@@ -19,7 +19,6 @@ export const Tasks: React.FC<TasksProps> = ({ server }) => {
       <UsersSyncTask server={server} />
       <LibrariesSyncTask server={server} />
       <Separator className="my-8" />
-      <DeleteServer server={server} />
     </div>
   );
 };

--- a/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
@@ -1,12 +1,14 @@
 "use server";
 
 import { Container } from "@/components/Container";
-import { getLibraries, getServer, getUser, getUsers } from "@/lib/db";
+import { getServer, getUser } from "@/lib/db";
+import { getLibrariesDirectlyFromJellyfin } from "@/lib/jellyfin";
 import { getMe } from "@/lib/me";
 import { redirect } from "next/navigation";
+import { DeleteServer } from "./DeleteServer";
 import JellystatsImport from "./JellystatsImport";
+import LibrarySettings from "./LibrarySettings";
 import { Tasks } from "./Tasks";
-import { TautulliMappingModal } from "./TautulliMappingModal";
 
 export default async function Settings({
   params,
@@ -23,6 +25,8 @@ export default async function Settings({
     redirect("/setup");
   }
 
+  const jellyfinLibraries = await getLibrariesDirectlyFromJellyfin(server);
+
   // const users = await getUsers(server.id);
   // const libraries = await getLibraries(server.id);
 
@@ -32,6 +36,7 @@ export default async function Settings({
       {user?.is_administrator ? (
         <>
           <Tasks server={server} />
+          <LibrarySettings server={server} libraries={jellyfinLibraries} />
           <div className="mt-8">
             <h2 className="text-2xl font-semibold mb-4">Jellystat import</h2>
 
@@ -57,6 +62,7 @@ export default async function Settings({
       ) : (
         <p>You are not an administrator of this server.</p>
       )}
+      <DeleteServer server={server} />
     </Container>
   );
 }

--- a/app/app/(app)/servers/[id]/login/SignInForm.tsx
+++ b/app/app/(app)/servers/[id]/login/SignInForm.tsx
@@ -27,7 +27,7 @@ import { Input } from "@/components/ui/input";
 import { tokenAtom } from "@/lib/atoms/tokenAtom";
 import { Server, login } from "@/lib/db";
 import { useAtom } from "jotai/react";
-import { Loader2 } from "lucide-react";
+import { Loader2, PlusCircle } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -132,13 +132,14 @@ export const SignInForm: React.FC<Props> = ({ server, servers }) => {
               <Button type="submit">{loading ? <Spinner /> : "Sign In"}</Button>
             </form>
           </Form>
+
           <div className="mt-6 space-y-4">
             <div className="flex items-center">
-              <div className="h-px flex-1 bg-border"></div>
+              <div className="h-px flex-1 bg-border" />
               <span className="px-2 text-xs text-muted-foreground">
                 Or select another server
               </span>
-              <div className="h-px flex-1 bg-border"></div>
+              <div className="h-px flex-1 bg-border" />
             </div>
 
             <div className="space-y-2">
@@ -164,6 +165,27 @@ export const SignInForm: React.FC<Props> = ({ server, servers }) => {
                   </p>
                 )}
               </div>
+            </div>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center">
+              <div className="h-px flex-1 bg-border" />
+              <span className="px-2 text-xs text-muted-foreground">
+                Or create a new server
+              </span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+
+            <div className="space-y-2">
+              <Button
+                variant="outline"
+                className="flex w-full items-center justify-center gap-2 rainbow-border-glow"
+                onClick={() => router.push("/setup")}
+              >
+                <PlusCircle className="h-4 w-4" />
+                <span>Add New Jellyfin Server</span>
+              </Button>
             </div>
           </div>
         </CardContent>

--- a/app/app/(app)/setup/SetupForm.tsx
+++ b/app/app/(app)/setup/SetupForm.tsx
@@ -4,7 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { PageTitle } from "@/components/PageTitle";
 import { Spinner } from "@/components/Spinner";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Form,
   FormControl,
@@ -28,6 +28,10 @@ import { createServer } from "@/lib/db";
 import { useRouter } from "nextjs-toploader/app";
 import { useState } from "react";
 import { toast } from "sonner";
+import {
+  CollectionFolder,
+  getLibrariesDirectlyFromJellyfin,
+} from "@/lib/jellyfin";
 
 const FormSchema = z.object({
   url: z.string().min(2, {
@@ -36,28 +40,76 @@ const FormSchema = z.object({
   apikey: z.string().min(2, {
     message: "Apikey must be at least 2 characters.",
   }),
+  libraries: z.array(z.string()).optional(),
 });
+
+type LibraryType = {
+  Id: string;
+  Name: string;
+  CollectionType?: string;
+};
 
 export function SetupForm() {
   const [loading, setLoading] = useState(false);
+  const [testingConnection, setTestingConnection] = useState(false);
+  const [libraries, setLibraries] = useState<CollectionFolder[]>([]);
+  const [showLibraries, setShowLibraries] = useState(false);
   const router = useRouter();
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       apikey: "",
       url: "",
+      libraries: [],
     },
   });
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    setLoading(true);
+  const { watch } = form;
+  const url = watch("url");
+  const apikey = watch("apikey");
+
+  async function testConnection() {
+    if (!url || !apikey) {
+      toast.error("Please enter a valid URL and API key");
+      return;
+    }
+
+    let _url = url.trim();
+    _url = _url.endsWith("/") ? _url.slice(0, -1) : _url;
+
+    setTestingConnection(true);
     try {
-      const server = await createServer(data.url, data.apikey);
+      const libraries = await getLibrariesDirectlyFromJellyfin({
+        api_key: apikey,
+        url: _url,
+      });
+
+      if (libraries.length === 0) throw new Error("No libraries found");
+
+      setLibraries(libraries);
+      setShowLibraries(true);
+      toast.success("Successfully connected to Jellyfin server");
+    } catch (error) {
+      console.error("Connection test failed:", error);
+      toast.error("Failed to connect to Jellyfin server");
+    } finally {
+      setTestingConnection(false);
+    }
+  }
+
+  async function onSubmit(data: z.infer<typeof FormSchema>) {
+    let url = data.url.trim();
+    url = url.endsWith("/") ? url.slice(0, -1) : url;
+
+    setLoading(true);
+
+    try {
+      const server = await createServer(url, data.apikey, data.libraries || []);
 
       if (!server || !server?.id) throw new Error("Server not created");
 
       router.push(`/servers/${server.id}/login`);
-      // You can add a success message or redirect the user here
     } catch (error) {
       console.error("Error creating server:", error);
       toast.error("Error creating server");
@@ -68,7 +120,7 @@ export function SetupForm() {
 
   return (
     <div className="flex h-screen w-full items-center justify-center px-4">
-      <Card className="mx-auto lg:min-w-[400px]">
+      <Card className="mx-auto lg:min-w-[500px]">
         <CardHeader>
           <CardTitle className="text-2xl">Set up</CardTitle>
           <CardDescription>
@@ -104,7 +156,7 @@ export function SetupForm() {
                   <FormItem>
                     <FormLabel>Jellyfin Api Key</FormLabel>
                     <FormControl>
-                      <Input placeholder="shadcn" {...field} />
+                      <Input placeholder="Your API key" {...field} />
                     </FormControl>
                     <FormDescription>
                       Get the api key from the admin dashboard in Jellyfin
@@ -113,7 +165,62 @@ export function SetupForm() {
                   </FormItem>
                 )}
               />
-              <Button type="submit" disabled={loading}>
+
+              {!showLibraries && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={testConnection}
+                  disabled={testingConnection}
+                  className="mr-2"
+                >
+                  {testingConnection ? <Spinner /> : "Test Connection"}
+                </Button>
+              )}
+
+              {showLibraries && libraries.length > 0 && (
+                <div className="space-y-4">
+                  <FormLabel>Select Libraries to Sync</FormLabel>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {libraries.map((library) => (
+                      <FormField
+                        key={library.Id}
+                        control={form.control}
+                        name="libraries"
+                        render={({ field }) => (
+                          <FormItem className="flex flex-row items-start space-x-3 space-y-0 border p-4 rounded-md">
+                            <FormControl>
+                              <Checkbox
+                                checked={field.value?.includes(library.Id)}
+                                onCheckedChange={(checked) => {
+                                  const currentValues = field.value || [];
+                                  const newValues = checked
+                                    ? [...currentValues, library.Id]
+                                    : currentValues.filter(
+                                        (value) => value !== library.Id
+                                      );
+                                  field.onChange(newValues);
+                                }}
+                              />
+                            </FormControl>
+                            <div className="space-y-1 leading-none">
+                              <FormLabel>{library.Name}</FormLabel>
+                              <FormDescription>
+                                {library.CollectionType || "Media"}
+                              </FormDescription>
+                            </div>
+                          </FormItem>
+                        )}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                disabled={loading || form.watch("libraries")?.length === 0}
+              >
                 {loading ? <Spinner /> : "Create"}
               </Button>
             </form>

--- a/app/app/api/Library/MediaFolders/route.ts
+++ b/app/app/api/Library/MediaFolders/route.ts
@@ -1,0 +1,71 @@
+import { getServer } from "@/lib/db";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get("url");
+  const apiKey = searchParams.get("apiKey");
+  const serverId = searchParams.get("serverId");
+
+  // We either need a serverId OR a url + apiKey pair
+  if (!serverId && (!url || !apiKey)) {
+    return new Response("Either serverId or url and apiKey are required", {
+      status: 400,
+    });
+  }
+
+  let serverUrl: string;
+  let serverApiKey: string;
+
+  if (serverId) {
+    const server = await getServer(serverId);
+    if (!server) {
+      return new Response("Server not found", { status: 404 });
+    }
+    serverUrl = server.url;
+    serverApiKey = server.api_key;
+  } else {
+    serverUrl = url!;
+    serverApiKey = apiKey!;
+  }
+
+  try {
+    const response = await fetch(`${serverUrl}/Library/MediaFolders`, {
+      method: "GET",
+      headers: {
+        "X-Emby-Token": serverApiKey,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Jellyfin API returned ${response.status}`);
+    }
+
+    const data = await response.json();
+    const libraries = data.Items.filter(
+      (library: any) =>
+        library.CollectionType !== "boxsets" &&
+        library.CollectionType !== "playlists",
+    );
+
+    return new Response(JSON.stringify(libraries), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching Jellyfin libraries:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to fetch libraries from Jellyfin server",
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  }
+}

--- a/app/lib/jellyfin.ts
+++ b/app/lib/jellyfin.ts
@@ -1,0 +1,76 @@
+export interface CollectionFolder {
+  Name: string;
+  ServerId: string;
+  Id: string;
+  Etag: string;
+  DateCreated: string;
+  CanDelete: boolean;
+  CanDownload: boolean;
+  SortName: string;
+  ExternalUrls: string[];
+  Path: string;
+  EnableMediaSourceDisplay: boolean;
+  ChannelId: null | string;
+  Taglines: string[];
+  Genres: string[];
+  RemoteTrailers: any[];
+  ProviderIds: Record<string, string>;
+  IsFolder: boolean;
+  ParentId: string;
+  Type: string;
+  People: any[];
+  Studios: any[];
+  GenreItems: any[];
+  LocalTrailerCount: number;
+  SpecialFeatureCount: number;
+  DisplayPreferencesId: string;
+  Tags: string[];
+  PrimaryImageAspectRatio: number;
+  CollectionType: string;
+  ImageTags: {
+    Primary: string;
+  };
+  BackdropImageTags: string[];
+  ImageBlurHashes: {
+    Primary: {
+      [key: string]: string;
+    };
+  };
+  LocationType: string;
+  MediaType: string;
+  LockedFields: any[];
+  LockData: boolean;
+}
+
+/**
+ * Fetches libraries from a Jellyfin server
+ * @param serverIdOrConfig Server ID or direct connection config with url and apiKey
+ * @returns The libraries from the Jellyfin server
+ */
+export async function getLibrariesDirectlyFromJellyfin(serverIdOrConfig: {
+  url: string;
+  api_key: string;
+}): Promise<CollectionFolder[]> {
+  // Make the API request to Jellyfin
+  const response = await fetch(`${serverIdOrConfig.url}/Library/MediaFolders`, {
+    method: "GET",
+    headers: {
+      "X-Emby-Token": serverIdOrConfig.api_key,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    console.error(`Jellyfin API returned ${response.status}`);
+    return [];
+  }
+
+  const data = await response.json();
+
+  // Filter out boxsets and playlists
+  return data.Items.filter(
+    (library: any) =>
+      library.CollectionType !== "boxsets" &&
+      library.CollectionType !== "playlists"
+  );
+}

--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
       ".expo",
       ".github",
       ".vscode",
+      ".next",
       "dist",
       "server"
     ]

--- a/server/lib/streamystat_server/servers/models/server.ex
+++ b/server/lib/streamystat_server/servers/models/server.ex
@@ -15,6 +15,7 @@ defmodule StreamystatServer.Servers.Models.Server do
           operating_system: String.t() | nil,
           jellyfin_id: String.t() | nil,
           startup_wizard_completed: boolean() | nil,
+          enabled_libraries: list(String.t()),
           inserted_at: NaiveDateTime.t() | nil,
           updated_at: NaiveDateTime.t() | nil
         }
@@ -31,6 +32,7 @@ defmodule StreamystatServer.Servers.Models.Server do
     field(:name, :string)
     field(:api_key, :string)
     field(:last_synced_playback_id, :integer, default: 0)
+    field(:enabled_libraries, {:array, :string}, default: [])
     timestamps()
   end
 
@@ -47,9 +49,10 @@ defmodule StreamystatServer.Servers.Models.Server do
       :startup_wizard_completed,
       :name,
       :api_key,
-      :last_synced_playback_id
+      :last_synced_playback_id,
+      :enabled_libraries
     ])
-    |> validate_required([:url, :api_key])
+    |> validate_required([:url, :api_key, :enabled_libraries])
     |> unique_constraint(:url)
   end
 end

--- a/server/lib/streamystat_server/servers/servers.ex
+++ b/server/lib/streamystat_server/servers/servers.ex
@@ -80,6 +80,22 @@ defmodule StreamystatServer.Servers.Servers do
     |> Repo.update()
   end
 
+  def update_server(id, attrs) when is_binary(id) or is_integer(id) do
+    case get_server(id) do
+      nil ->
+        {:error, :not_found}
+      server ->
+        case update_server(server, attrs) do
+          {:ok, updated_server} ->
+            # Trigger a full sync after successful update
+            StreamystatServer.Workers.SyncTask.full_sync(updated_server.id)
+            {:ok, updated_server}
+          error ->
+            error
+        end
+    end
+  end
+
   def delete_server(%Server{} = server) do
     Repo.delete(server)
   end

--- a/server/lib/streamystat_server/workers/sync_task.ex
+++ b/server/lib/streamystat_server/workers/sync_task.ex
@@ -223,7 +223,6 @@ defmodule StreamystatServer.Workers.SyncTask do
   end
 
   defp perform_full_sync(server) do
-    # Run each sync operation and collect results
     # Users
     {users_result, _} = Sync.sync_users(server)
     Logger.info("Users sync completed with result: #{inspect(users_result)}")

--- a/server/lib/streamystat_server_web/controllers/server_controller.ex
+++ b/server/lib/streamystat_server_web/controllers/server_controller.ex
@@ -35,6 +35,21 @@ defmodule StreamystatServerWeb.ServerController do
     end
   end
 
+  def update(conn, %{"server_id" => id} = params) do
+    # Extract all server-related params to pass to update_server
+    server_params = Map.drop(params, ["server_id"])
+
+    case Servers.update_server(id, server_params) do
+      {:ok, server} ->
+        render(conn, :show, server: server)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(json: StreamystatServerWeb.ChangesetJSON)
+        |> render(:error, changeset: changeset)
+    end
+  end
+
   def delete(conn, %{"server_id" => id}) do
     case Servers.delete_server(id) do
       {:ok, _} ->

--- a/server/lib/streamystat_server_web/controllers/server_json.ex
+++ b/server/lib/streamystat_server_web/controllers/server_json.ex
@@ -22,7 +22,8 @@ defmodule StreamystatServerWeb.ServerJSON do
       url: server.url,
       api_key: server.api_key,
       inserted_at: server.inserted_at,
-      updated_at: server.updated_at
+      updated_at: server.updated_at,
+      enabled_libraries: server.enabled_libraries
     }
   end
 end

--- a/server/lib/streamystat_server_web/router.ex
+++ b/server/lib/streamystat_server_web/router.ex
@@ -36,6 +36,7 @@ defmodule StreamystatServerWeb.Router do
       pipe_through(:admin_auth)
 
       delete("/servers/:server_id", ServerController, :delete)
+      put("/servers/:server_id", ServerController, :update)
       post("/servers/:server_id/sync/full", SyncController, :full_sync)
       post("/servers/:server_id/sync/users", SyncController, :sync_users)
       post("/servers/:server_id/sync/libraries", SyncController, :sync_libraries)

--- a/server/priv/repo/migrations/20250412075632_add_enabled_libraries_to_servers.exs
+++ b/server/priv/repo/migrations/20250412075632_add_enabled_libraries_to_servers.exs
@@ -1,0 +1,9 @@
+defmodule StreamystatServer.Repo.Migrations.AddEnabledLibrariesToServers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:servers) do
+      add :enabled_libraries, {:array, :string}, default: [], null: false
+    end
+  end
+end


### PR DESCRIPTION
This allows an admin to select the libraries to sync, and subsequently the items counted towards the statistics. 

Frontend:
- Improves the setup form with library selection
- Adds a settings form with library selection

Backend:
- Adds enabled_libraries to the server table
- Sync Task only runs for enabled libraries
- Start full sync task after updating the enabled libraries 