### PR TITLE
fix: users WatchTimePerDay - Invalid Date

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/users/[name]/WatchTimePerDay.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/users/[name]/WatchTimePerDay.tsx
@@ -56,7 +56,6 @@ export const WatchTimePerDay: React.FC<Props> = ({ data }) => {
               tickLine={false}
               tickMargin={10}
               axisLine={false}
-              tickFormatter={(date) => new Date(date).toLocaleDateString()}
             />
             <ChartTooltip
               cursor={false}

--- a/app/app/(app)/servers/[id]/(auth)/users/[name]/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/users/[name]/page.tsx
@@ -7,7 +7,7 @@ import { redirect } from "next/navigation";
 import { HistoryTable } from "../../history/HistoryTable";
 import { GenreStatsGraph } from "./GenreStatsGraph";
 import UserBadges from "./UserBadges";
-import { WatchTimePerDay } from "./WatchTimePerDay.tsx";
+import { WatchTimePerDay } from "./WatchTimePerDay";
 
 export default async function User({
   params,


### PR DESCRIPTION
The date on the users watch time per day table is not formatted correctly, because the date is converted twice to the locale format (first in [line 38](https://github.com/Namo2/streamystats/blob/9bab785305f4fb738f3df5fec085b2b84d9e36c5/app/app/(app)/servers/%5Bid%5D/(auth)/users/%5Bname%5D/WatchTimePerDay.tsx#L38) and then in - _now removed_ - [line 59](https://github.com/Namo2/streamystats/blob/9bab785305f4fb738f3df5fec085b2b84d9e36c5/app/app/(app)/servers/%5Bid%5D/(auth)/users/%5Bname%5D/WatchTimePerDay.tsx#L59))

I also fixed the double extension in the file name

Before:
![image](https://github.com/user-attachments/assets/3d62265d-4edb-43e5-855c-74172395b7d5)

After:
![image](https://github.com/user-attachments/assets/3f477cbe-d2a4-44ea-a8d4-d24317a4b35c)

## Summary by Sourcery

Fix date formatting issue in the Users Watch Time Per Day table

Bug Fixes:
- Removed redundant date formatting that was causing incorrect date display in the WatchTimePerDay component

Enhancements:
- Corrected file import by removing the duplicate '.tsx' extension