### PR TITLE
feat: playback reporting plugin import data

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { importPlaybackReporting } from "@/lib/importPlaybackReporting";
+import {
+  AlertCircle,
+  CheckCircle2,
+  HelpCircle,
+  Info,
+  Loader2,
+  Upload,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+
+// Form submit button with loading state
+function SubmitButton({ hasFile }: { hasFile: boolean }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending || !hasFile} className="w-full">
+      {pending ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Uploading...
+        </>
+      ) : (
+        <>
+          <Upload className="mr-2 h-4 w-4" />
+          Upload and Import
+        </>
+      )}
+    </Button>
+  );
+}
+
+export default function PlaybackReportingImport({
+  serverId,
+}: {
+  serverId: number;
+}) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [state, formAction] = useFormState(importPlaybackReporting, {
+    type: null,
+    message: "",
+  });
+
+  // Handle file selection
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const file = e.target.files[0];
+      if (
+        file.type === "application/json" ||
+        file.name.endsWith(".json") ||
+        file.type === "text/tab-separated-values" ||
+        file.name.endsWith(".tsv") ||
+        file.name.endsWith(".txt")
+      ) {
+        setSelectedFile(file);
+      } else {
+        setSelectedFile(null);
+        // Reset the file input
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    } else {
+      setSelectedFile(null);
+    }
+  };
+
+  // Reset the form after a successful upload
+  useEffect(() => {
+    if (state.type === "success" && fileInputRef.current) {
+      setSelectedFile(null);
+      fileInputRef.current.value = "";
+    }
+  }, [state]);
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="text-xl">
+          Import from Playback Reporting
+        </CardTitle>
+        <CardDescription>
+          Import your playback history from a Playback Reporting export file
+          (JSON or TSV format)
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={formAction} className="space-y-4">
+          {/* Hidden input for server ID */}
+          <input type="hidden" name="serverId" value={serverId} />
+
+          <div className="space-y-2 flex flex-col">
+            <label
+              htmlFor="playback-reporting-file"
+              className="text-sm font-medium"
+            >
+              Playback Reporting Export File
+            </label>
+            <Input
+              ref={fileInputRef}
+              id="playback-reporting-file"
+              name="file"
+              type="file"
+              accept=".json,application/json,.tsv,text/tab-separated-values,.txt"
+              onChange={handleFileChange}
+              className="cursor-pointer"
+            />
+            {selectedFile && (
+              <p className="text-sm text-muted-foreground">
+                Selected file: {selectedFile.name} (
+                {(selectedFile.size / 1024 / 1024).toFixed(2)} MB)
+              </p>
+            )}
+          </div>
+
+          {state?.type && (
+            <Alert variant={state.type === "error" ? "destructive" : "default"}>
+              {state.type === "success" && <CheckCircle2 className="h-4 w-4" />}
+              {state.type === "error" && <AlertCircle className="h-4 w-4" />}
+              {state.type === "info" && <Info className="h-4 w-4" />}
+              <AlertTitle>
+                {state.type === "success" && "Success"}
+                {state.type === "error" && "Error"}
+                {state.type === "info" && "Information"}
+              </AlertTitle>
+              <AlertDescription>{state.message}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="pt-2">
+            <SubmitButton hasFile={!!selectedFile} />
+          </div>
+        </form>
+
+        <Accordion type="single" collapsible className="mt-6">
+          <AccordionItem value="instructions">
+            <AccordionTrigger className="flex items-center text-sm font-medium">
+              <HelpCircle className="mr-2 h-4 w-4" />
+              How to export data from Playback Reporting
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="text-sm text-muted-foreground space-y-2 pt-2 pl-1">
+                <ol className="list-decimal pl-5 space-y-1.5">
+                  <li>Open your Jellyfin admin dashboard</li>
+                  <li>Go to the Playback Reporting plugin settings</li>
+                  <li>Click on "Export to CSV/JSON" option</li>
+                  <li>Select your preferred export format (JSON or TSV)</li>
+                  <li>Download the exported file</li>
+                  <li>Upload it here</li>
+                </ol>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
@@ -164,8 +164,7 @@ export default function PlaybackReportingImport({
                 <ol className="list-decimal pl-5 space-y-1.5">
                   <li>Open your Jellyfin admin dashboard</li>
                   <li>Go to the Playback Reporting plugin settings</li>
-                  <li>Click on "Export to CSV/JSON" option</li>
-                  <li>Select your preferred export format (JSON or TSV)</li>
+                  <li>Click on Save Backup Data under the Backup section</li>
                   <li>Download the exported file</li>
                   <li>Upload it here</li>
                 </ol>

--- a/app/app/(app)/servers/[id]/(auth)/settings/VersionSection.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/VersionSection.tsx
@@ -19,18 +19,6 @@ export const VersionSection = () => {
                 "Not available"}
             </p>
           </div>
-          <div className="space-y-1">
-            <p className="text-sm font-medium text-muted-foreground">
-              Build Time
-            </p>
-            <p className="font-mono text-foreground bg-muted px-2 py-1 rounded-md inline-block">
-              {process.env.NEXT_PUBLIC_BUILD_TIME
-                ? new Date(
-                    Number(process.env.NEXT_PUBLIC_BUILD_TIME) * 1000
-                  ).toLocaleString()
-                : "Not available"}
-            </p>
-          </div>
         </div>
       </div>
     </div>

--- a/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
@@ -7,6 +7,13 @@ import { DeleteServer } from "./DeleteServer";
 import JellystatsImport from "./JellystatsImport";
 import { Tasks } from "./Tasks";
 import { VersionSection } from "./VersionSection";
+import PlaybackReportingImport from "./PlaybackReportingImport";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 export default async function Settings({
   params,
@@ -24,10 +31,27 @@ export default async function Settings({
     <Container className="">
       <h1 className="text-3xl font-bold mb-8">Settings</h1>
       <Tasks server={server} />
-      <div className="mb-4">
-        <h2 className="text-2xl font-semibold mb-4">Jellystat import</h2>
-        <JellystatsImport serverId={server.id} />
-      </div>
+      <Accordion type="single" collapsible className="mb-4">
+        <AccordionItem value="jellystat-import">
+          <AccordionTrigger className="text-2xl font-semibold">
+            Jellystat Import
+          </AccordionTrigger>
+          <AccordionContent>
+            <JellystatsImport serverId={server.id} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      <Accordion type="single" collapsible className="mb-4">
+        <AccordionItem value="playback-reporting-import">
+          <AccordionTrigger className="text-2xl font-semibold">
+            Playback Reporting Plugin Import
+          </AccordionTrigger>
+          <AccordionContent>
+            <PlaybackReportingImport serverId={server.id} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
       <VersionSection />
       <DeleteServer server={server} />
     </Container>

--- a/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
@@ -40,9 +40,6 @@ export default async function Settings({
             <JellystatsImport serverId={server.id} />
           </AccordionContent>
         </AccordionItem>
-      </Accordion>
-
-      <Accordion type="single" collapsible className="mb-4">
         <AccordionItem value="playback-reporting-import">
           <AccordionTrigger className="text-2xl font-semibold">
             Playback Reporting Plugin Import

--- a/app/components/VersionBadge.tsx
+++ b/app/components/VersionBadge.tsx
@@ -1,7 +1,11 @@
-export const VersionBadge = () => (
-  <div className="fixed bottom-2 right-2 bg-gray-800 text-white text-xs px-2 py-1 rounded">
-    <code suppressHydrationWarning>
-      {process.env.NEXT_PUBLIC_VERSION ?? "edge"}
-    </code>
-  </div>
-);
+export const VersionBadge = () => {
+  const sha = process.env.NEXT_PUBLIC_COMMIT_SHA?.substring(0, 7);
+  return (
+    <div className="fixed bottom-2 right-2 bg-gray-800 text-white text-xs px-2 py-1 rounded">
+      <code suppressHydrationWarning>
+        {process.env.NEXT_PUBLIC_VERSION ?? "edge"}
+        {sha && ` (${sha})`}
+      </code>
+    </div>
+  );
+};

--- a/app/lib/importPlaybackReporting.ts
+++ b/app/lib/importPlaybackReporting.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getToken } from "./token";
+
+type State = {
+  type: "success" | "error" | "info" | null;
+  message: string;
+};
+
+export const importPlaybackReporting = async (
+  prevState: State,
+  formData: FormData
+): Promise<State> => {
+  const file = formData.get("file") as File | null;
+  const serverId = formData.get("serverId") as string;
+
+  if (!file) {
+    return { type: "error", message: "No file selected" };
+  }
+
+  if (!serverId) {
+    return { type: "error", message: "Server ID is missing" };
+  }
+
+  try {
+    // Validate file type (accepts JSON and TSV files)
+    const isJson =
+      file.type === "application/json" || file.name.endsWith(".json");
+    const isTsv =
+      file.type === "text/tab-separated-values" ||
+      file.name.endsWith(".tsv") ||
+      file.name.endsWith(".txt");
+
+    if (!isJson && !isTsv) {
+      return {
+        type: "error",
+        message: "Invalid file type. Please select a JSON or TSV file.",
+      };
+    }
+
+    // Prepare FormData for API request
+    const apiFormData = new FormData();
+    apiFormData.append("file", file);
+
+    // Make API request to backend
+    const response = await fetch(
+      `${process.env.API_URL}/admin/servers/${serverId}/playback-reporting/import`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await getToken()}`,
+        },
+        body: apiFormData,
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return {
+        type: "error",
+        message:
+          errorData.error ||
+          "Failed to import Playback Reporting data. Please try again.",
+      };
+    }
+
+    // Successful response
+    revalidatePath(`/servers/${serverId}/settings`);
+
+    return {
+      type: "success",
+      message:
+        "Your Playback Reporting data is being imported! This process runs in the background and may take several minutes depending on the amount of data.",
+    };
+  } catch (error) {
+    console.error("Error uploading Playback Reporting data:", error);
+    return {
+      type: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred. Please try again.",
+    };
+  }
+};

--- a/server/lib/streamystat_server/application.ex
+++ b/server/lib/streamystat_server/application.ex
@@ -19,6 +19,7 @@ defmodule StreamystatServer.Application do
       StreamystatServer.Workers.SessionPoller,
       StreamystatServer.Workers.TautulliImporter,
       StreamystatServer.Workers.JellystatsImporter,
+      StreamystatServer.Workers.PlaybackReportingImporter,
       {Task, &start_full_sync/0}
     ]
 

--- a/server/lib/streamystat_server/workers/playback_reporting_importer.ex
+++ b/server/lib/streamystat_server/workers/playback_reporting_importer.ex
@@ -63,6 +63,14 @@ defmodule StreamystatServer.Workers.PlaybackReportingImporter do
   end
 
   @impl true
+  def handle_info({ref, result}, state) when is_reference(ref) do
+    # We don't care about the DOWN message now, so let's demonitor and flush it
+    Process.demonitor(ref, [:flush])
+    GenServer.cast(__MODULE__, {:import_complete, result})
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
     Logger.error("Import task crashed: #{inspect(reason)}")
     {:noreply, %{state | importing: false, current_server_id: nil}}

--- a/server/lib/streamystat_server/workers/playback_reporting_importer.ex
+++ b/server/lib/streamystat_server/workers/playback_reporting_importer.ex
@@ -1,0 +1,550 @@
+defmodule StreamystatServer.Workers.PlaybackReportingImporter do
+  use GenServer
+  require Logger
+  alias StreamystatServer.Repo
+  alias StreamystatServer.Servers.Models.Server
+  alias StreamystatServer.Jellyfin.Models.User
+  alias StreamystatServer.Jellyfin.Models.Item
+  alias StreamystatServer.Sessions.Models.PlaybackSession
+  import Ecto.Query
+
+  # Batch size for database operations
+  @batch_size 50
+  # Timeout for DB operations
+  @db_timeout 30_000
+
+  # Client API
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  # Update to accept file_type parameter
+  def import_data(server_id, data, file_type \\ "json") do
+    GenServer.cast(__MODULE__, {:import, server_id, data, file_type})
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{importing: false, current_server_id: nil}}
+  end
+
+  @impl true
+  def handle_cast({:import, server_id, data, file_type}, state) do
+    if state.importing do
+      Logger.info("Playback Reporting import already in progress for server_id: #{state.current_server_id}, skipping new request for server_id: #{server_id}")
+      {:noreply, state}
+    else
+      data_size = if is_binary(data), do: String.length(data), else: "unknown"
+      Logger.info("Starting Playback Reporting import for server_id: #{server_id} with file type: #{file_type}, data size: #{data_size} bytes")
+
+      # Spawn the import process
+      task = Task.async(fn ->
+        Logger.info("Import task started for server_id: #{server_id}")
+        result = do_import(server_id, data, file_type)
+        Logger.info("Import task completed for server_id: #{server_id} with result: #{inspect(result)}")
+        result
+      end)
+
+      # Monitor the task for failures
+      Process.monitor(task.pid)
+
+      Logger.info("Import task spawned with PID: #{inspect(task.pid)}")
+      {:noreply, %{state | importing: true, current_server_id: server_id}}
+    end
+  end
+
+  @impl true
+  def handle_cast({:import_complete, result}, state) do
+    Logger.info("Playback Reporting import completed for server_id: #{state.current_server_id}, result: #{inspect(result)}")
+    {:noreply, %{state | importing: false, current_server_id: nil}}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
+    Logger.error("Import task crashed: #{inspect(reason)}")
+    {:noreply, %{state | importing: false, current_server_id: nil}}
+  end
+
+  # Update do_import to handle different file types
+  defp do_import(server_id, data, file_type) do
+    Logger.debug("Looking up server with ID: #{server_id}")
+
+    try do
+      server = Repo.get(Server, server_id)
+
+      if server do
+        Logger.info("Found server: #{server.name} (ID: #{server.id})")
+
+        # Process data based on file type
+        activities = case file_type do
+          "json" -> decode_json_data(data)
+          "tsv" -> parse_tsv_data(data)
+          _ ->
+            Logger.error("Unsupported file type: #{file_type}")
+            []
+        end
+
+        # Process the data sections
+        process_playback_activities_batch(server, activities)
+      else
+        Logger.error("Server with ID #{server_id} not found")
+        {:error, :server_not_found}
+      end
+    rescue
+      e ->
+        Logger.error("Error during import: #{inspect(e)}")
+        Logger.error(Exception.format_stacktrace())
+        {:error, e}
+    end
+  end
+
+  # Rename the old decode_data to decode_json_data
+  defp decode_json_data(data) when is_binary(data) do
+    case Jason.decode(data) do
+      {:ok, decoded} ->
+        # Log the structure to help debug
+        Logger.debug("Decoded JSON structure: #{inspect(decoded, pretty: true)}")
+        decoded
+      {:error, error} ->
+        Logger.error("Failed to decode JSON data: #{inspect(error)}")
+        []
+    end
+  end
+
+  defp decode_json_data(data) when is_list(data), do: data
+  defp decode_json_data(_), do: []
+
+  # New function to parse TSV data with enhanced logging
+  defp parse_tsv_data(data) when is_binary(data) do
+    Logger.info("Parsing TSV data (length: #{String.length(data)} bytes)")
+
+    # Log a sample of the data
+    sample = if String.length(data) > 500, do: String.slice(data, 0, 500) <> "...", else: data
+    Logger.debug("TSV data sample: #{inspect(sample)}")
+
+    # Split the data into lines
+    lines = String.split(data, ~r/\r?\n/, trim: true)
+    Logger.info("Found #{length(lines)} lines in TSV data")
+
+    # Log the first few lines to help debug the format
+    sample_lines = Enum.take(lines, 3)
+    Logger.debug("Sample lines: #{inspect(sample_lines)}")
+
+    # Process each line into a map
+    parsed_activities = Enum.map(lines, fn line ->
+      fields = String.split(line, "\t")
+      Logger.debug("Line has #{length(fields)} fields: #{inspect(fields)}")
+
+      # Check if we have enough fields - adjust based on your TSV format
+      case fields do
+        [date, user_id, item_id, item_type, item_name, playback_method, client_name, device_name, play_duration | _rest] ->
+          %{
+            "DateCreated" => date,
+            "UserId" => user_id,
+            "ItemId" => item_id,
+            "ItemType" => item_type,
+            "ItemName" => item_name,
+            "PlaybackMethod" => playback_method,
+            "ClientName" => client_name,
+            "DeviceName" => device_name,
+            "PlayDuration" => play_duration
+          }
+        _ ->
+          Logger.warning("Skipping invalid TSV line: #{line}")
+          nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+
+    Logger.info("Successfully parsed #{length(parsed_activities)} activities from TSV data")
+
+    if parsed_activities == [] do
+      Logger.error("No valid activities found in TSV data")
+    end
+
+    parsed_activities
+  end
+
+  defp parse_tsv_data(_), do: []
+
+  # Process playback activities with batch operations
+  defp process_playback_activities_batch(server, activities) when is_list(activities) do
+    Logger.info("Processing #{length(activities)} playback activities in batches")
+
+    try do
+      # Process in smaller batches to prevent crashes
+      results = activities
+      |> Enum.chunk_every(@batch_size)
+      |> Enum.reduce(%{created: 0, updated: 0, skipped: 0, errors: 0}, fn batch, acc ->
+        # Add error handling with retry logic around each batch
+        case safe_process_batch(server, batch, acc) do
+          {:ok, batch_results} ->
+            # Combine results from this batch with overall results
+            %{
+              created: acc.created + batch_results.created,
+              updated: acc.updated + batch_results.updated,
+              skipped: acc.skipped + batch_results.skipped,
+              errors: acc.errors + batch_results.errors
+            }
+          {:error, _reason} ->
+            # Just count the entire batch as errors
+            %{acc | errors: acc.errors + length(batch)}
+        end
+      end)
+
+      Logger.info("Processed #{length(activities)} playback activities: created=#{results.created}, updated=#{results.updated}, skipped=#{results.skipped}, errors=#{results.errors}")
+
+      results
+    rescue
+      e ->
+        Logger.error("Error processing playback activities: #{inspect(e)}")
+        %{created: 0, updated: 0, skipped: 0, errors: length(activities)}
+    end
+  end
+
+  defp process_playback_activities_batch(_, _), do: %{created: 0, updated: 0, skipped: 0, errors: 0}
+
+  # Safely load users in a separate transaction
+  defp safely_load_users(server) do
+    try do
+      users_map = Repo.transaction(fn ->
+        users_query = from u in User,
+                  where: u.server_id == ^server.id,
+                  select: {u.jellyfin_id, u}
+        Repo.all(users_query, timeout: @db_timeout)
+      end, timeout: @db_timeout)
+
+      case users_map do
+        {:ok, results} -> {:ok, Map.new(results)}
+        error -> error
+      end
+    rescue
+      e ->
+        Logger.error("Error loading users: #{inspect(e)}")
+        {:error, e}
+    end
+  end
+
+  # Safely load items in a separate transaction
+  defp safely_load_items(server) do
+    try do
+      items_map = Repo.transaction(fn ->
+        items_query = from i in Item,
+                    where: i.server_id == ^server.id,
+                    select: {i.jellyfin_id, i}
+        Repo.all(items_query, timeout: @db_timeout)
+      end, timeout: @db_timeout)
+
+      case items_map do
+        {:ok, results} -> {:ok, Map.new(results)}
+        error -> error
+      end
+    rescue
+      e ->
+        Logger.error("Error loading items: #{inspect(e)}")
+        {:error, e}
+    end
+  end
+
+  # Add a new function with retry logic for each batch
+  defp safe_process_batch(server, batch, _acc, retry_count \\ 0) do
+    # Preload users and items in separate transactions
+    with {:ok, users_map} <- safely_load_users(server),
+         {:ok, items_map} <- safely_load_items(server) do
+
+      # Process the batch with the loaded maps
+      try do
+        results = process_playback_batch(server, batch, users_map, items_map)
+        {:ok, results}
+      rescue
+        e in DBConnection.ConnectionError ->
+          handle_db_error(e, server, batch, retry_count)
+        e ->
+          Logger.error("Error processing batch: #{inspect(e, pretty: true)}")
+          Logger.error(Exception.format_stacktrace())
+          {:error, e}
+      end
+    else
+      {:error, reason} ->
+        Logger.error("Failed to preload data: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp handle_db_error(error, server, batch, retry_count) do
+    max_retries = 3
+
+    if retry_count < max_retries do
+      # Wait a bit before retrying (with exponential backoff)
+      backoff = :math.pow(2, retry_count) * 1000 |> round()
+      Logger.warning("Database error, retrying batch in #{backoff}ms (attempt #{retry_count + 1}/#{max_retries}): #{inspect(error.message)}")
+
+      :timer.sleep(backoff)
+      safe_process_batch(server, batch, %{}, retry_count + 1)
+    else
+      Logger.error("Failed to process batch after #{max_retries} attempts: #{inspect(error.message)}")
+      {:error, error}
+    end
+  end
+
+  defp process_playback_batch(server, activities, users_map, items_map) do
+    # Get the item and user ids directly
+    item_ids = Enum.map(activities, fn activity ->
+      activity["ItemId"]
+    end)
+    |> Enum.reject(&is_nil/1)
+
+    user_ids = Enum.map(activities, fn activity -> activity["UserId"] end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&(&1 == ""))
+
+    # Skip the query if we have no valid IDs
+    existing_sessions = if Enum.empty?(item_ids) do
+      %{}
+    else
+      # Query for existing sessions in a smaller transaction
+      try do
+        query_result = Repo.transaction(fn ->
+          existing_query =
+            if Enum.empty?(user_ids) do
+              # Handle anonymous sessions where UserId might be empty
+              from s in PlaybackSession,
+              where: s.server_id == ^server.id and
+                    s.item_jellyfin_id in ^item_ids,
+              select: {s.item_jellyfin_id, s.start_time, s}
+            else
+              from s in PlaybackSession,
+              where: s.server_id == ^server.id and
+                    s.item_jellyfin_id in ^item_ids and
+                    s.user_jellyfin_id in ^user_ids,
+              select: {s.item_jellyfin_id, s.user_jellyfin_id, s.start_time, s}
+            end
+
+          Repo.all(existing_query, timeout: @db_timeout)
+        end, timeout: @db_timeout)
+
+        case query_result do
+          {:ok, existing_sessions_list} ->
+            # Convert to map for easier lookup
+            Enum.reduce(existing_sessions_list, %{}, fn
+              {item_id, user_id, start_time, session}, acc when is_binary(user_id) ->
+                Map.put(acc, {item_id, user_id, start_time}, session)
+              {item_id, start_time, session}, acc ->
+                Map.put(acc, {item_id, start_time}, session)
+            end)
+          _ -> %{}
+        end
+      rescue
+        e ->
+          Logger.error("Error querying existing sessions: #{inspect(e)}")
+          %{}
+      end
+    end
+
+    # Process each activity using smaller transactions
+    Enum.reduce(activities, %{created: 0, updated: 0, skipped: 0, errors: 0}, fn activity, acc ->
+      try do
+        result = Repo.transaction(fn ->
+          create_playback_session_from_report(server, activity, users_map, items_map, existing_sessions)
+        end, timeout: @db_timeout)
+
+        case result do
+          {:ok, {:ok, :created, _}} -> Map.update!(acc, :created, &(&1 + 1))
+          {:ok, {:ok, :updated, _}} -> Map.update!(acc, :updated, &(&1 + 1))
+          {:ok, {:skip, _}} -> Map.update!(acc, :skipped, &(&1 + 1))
+          _ -> Map.update!(acc, :errors, &(&1 + 1))
+        end
+      rescue
+        _ -> Map.update!(acc, :errors, &(&1 + 1))
+      end
+    end)
+  end
+
+  defp create_playback_session_from_report(server, activity, users_map, items_map, existing_sessions) do
+    try do
+      user_jellyfin_id = activity["UserId"]
+      user =
+        if user_jellyfin_id && user_jellyfin_id != "" do
+          Map.get(users_map, user_jellyfin_id)
+        else
+          nil
+        end
+
+      activity_date = parse_date(activity["DateCreated"])
+      play_duration =
+        case activity["PlayDuration"] do
+          duration when is_binary(duration) -> String.to_integer(duration)
+          duration when is_integer(duration) -> duration
+          _ -> 0
+        end
+
+      item_jellyfin_id = activity["ItemId"]
+      item_name = activity["ItemName"]
+      item_type = activity["ItemType"]
+
+      # Extract series name and episode details if available
+      {series_name, item_name} = extract_series_info(item_name, item_type)
+
+      item = Map.get(items_map, item_jellyfin_id)
+
+      runtime_ticks =
+        case item do
+          %Item{runtime_ticks: ticks} when not is_nil(ticks) -> ticks
+          _ -> 0
+        end
+
+      percent_complete =
+        if runtime_ticks > 0 do
+          # Convert play_duration from seconds to ticks for comparison
+          play_duration_ticks = play_duration * 10_000
+          # Calculate percentage
+          (play_duration_ticks / runtime_ticks) * 100.0
+        else
+          # Default to 0 if we can't calculate
+          0.0
+        end
+
+      # Session is considered completed if progress is > 90%
+      completed = percent_complete > 90.0
+
+      end_time =
+        if activity_date && play_duration && play_duration > 0 do
+          DateTime.add(activity_date, play_duration, :second)
+        else
+          nil
+        end
+
+      # Map PlaybackMethod to play_method format
+      play_method = map_playback_method(activity["PlaybackMethod"])
+
+      attrs = %{
+        user_id: user && user.id,
+        user_jellyfin_id: if(user_jellyfin_id == "", do: nil, else: user_jellyfin_id),
+        device_id: nil, # Not provided in Playback Reporting
+        device_name: activity["DeviceName"] || "",
+        client_name: activity["ClientName"],
+        item_jellyfin_id: item_jellyfin_id,
+        item_name: item_name,
+        series_jellyfin_id: item && item.series_id,
+        series_name: series_name,
+        season_jellyfin_id: item && item.season_id,
+        play_duration: play_duration,
+        play_method: play_method,
+        start_time: activity_date,
+        end_time: end_time,
+        position_ticks: nil, # Not provided in Playback Reporting
+        runtime_ticks: runtime_ticks,
+        percent_complete: percent_complete,
+        completed: completed,
+        server_id: server.id
+      }
+
+      # Check if this session already exists in our lookup map
+      existing_key =
+        if user_jellyfin_id && user_jellyfin_id != "" do
+          {item_jellyfin_id, user_jellyfin_id, activity_date}
+        else
+          {item_jellyfin_id, activity_date}
+        end
+
+      existing_session = Map.get(existing_sessions, existing_key)
+
+      if is_nil(existing_session) do
+        result = %PlaybackSession{}
+        |> PlaybackSession.changeset(attrs)
+        |> Repo.insert(timeout: @db_timeout)
+
+        case result do
+          {:ok, session} ->
+            {:ok, :created, session}
+          {:error, changeset} ->
+            Logger.error("Failed to create playback session: #{inspect(changeset.errors)}")
+            {:error, changeset}
+        end
+      else
+        # Only update if the new data has more information
+        if should_update_session?(existing_session, attrs) do
+          result = existing_session
+          |> PlaybackSession.changeset(attrs)
+          |> Repo.update(timeout: @db_timeout)
+
+          case result do
+            {:ok, session} ->
+              {:ok, :updated, session}
+            {:error, changeset} ->
+              Logger.error("Failed to update playback session: #{inspect(changeset.errors)}")
+              {:error, changeset}
+          end
+        else
+          {:skip, "Existing session has better data"}
+        end
+      end
+    catch
+      _ -> {:error, "Unexpected error occurred"}
+    end
+  end
+
+  # Helper to map Playback Reporting's PlaybackMethod to our format
+  defp map_playback_method("DirectPlay"), do: "Direct"
+  defp map_playback_method("DirectStream"), do: "DirectStream"
+  defp map_playback_method(method) when is_binary(method) do
+    cond do
+      String.starts_with?(method, "Transcode") -> "Transcode"
+      true -> method
+    end
+  end
+  defp map_playback_method(_), do: "Unknown"
+
+  # Extract series name from the item name for TV episodes
+  defp extract_series_info(item_name, "Episode") do
+    case Regex.run(~r/^(.*?) - s\d+e\d+ - (.*)$/, item_name) do
+      [_, series, episode] -> {series, episode}
+      _ -> {nil, item_name}
+    end
+  end
+  defp extract_series_info(item_name, _), do: {nil, item_name}
+
+  # Helper functions
+  defp should_update_session?(existing, new) do
+    # Update if:
+    # 1. New session has longer duration
+    # 2. New session has more progress
+    # 3. New session has more complete data
+    new.play_duration > existing.play_duration ||
+      (new.position_ticks || 0) > (existing.position_ticks || 0) ||
+      (is_nil(existing.end_time) && !is_nil(new.end_time))
+  end
+
+  defp parse_date(nil), do: nil
+  defp parse_date(date) when is_binary(date) do
+    # Try ISO8601 format first
+    case DateTime.from_iso8601(date) do
+      {:ok, dt, _} -> dt
+      {:error, _} ->
+        # Try SQL Server datetime format
+        case NaiveDateTime.from_iso8601(date) do
+          {:ok, ndt} ->
+            case DateTime.from_naive(ndt, "Etc/UTC") do
+              {:ok, dt} -> dt
+              _ -> nil
+            end
+          _ ->
+            # Try SQL Server datetime format with milliseconds
+            date_pattern = ~r/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d+)$/
+            case Regex.run(date_pattern, date) do
+              [_, year, month, day, hour, minute, second, ms] ->
+                # Build the datetime string
+                iso_string = "#{year}-#{month}-#{day}T#{hour}:#{minute}:#{second}.#{ms}Z"
+                case DateTime.from_iso8601(iso_string) do
+                  {:ok, dt, _} -> dt
+                  _ -> nil
+                end
+              _ -> nil
+            end
+        end
+    end
+  end
+end

--- a/server/lib/streamystat_server_web/controllers/playback_reporting_import_controller.ex
+++ b/server/lib/streamystat_server_web/controllers/playback_reporting_import_controller.ex
@@ -1,0 +1,79 @@
+defmodule StreamystatServerWeb.PlaybackReportingImportController do
+  use StreamystatServerWeb, :controller
+  require Logger
+  alias StreamystatServer.Workers.PlaybackReportingImporter
+
+  def import(conn, %{"server_id" => server_id} = params) do
+    Logger.info("Playback Reporting import request received for server: #{server_id}")
+
+    case get_import_data(conn, params) do
+      {:ok, import_data, file_type} ->
+        # Start the import process
+        PlaybackReportingImporter.import_data(server_id, import_data, file_type)
+
+        conn
+        |> put_status(:accepted)
+        |> render(:import, message: "Playback Reporting import started successfully", status: "processing")
+
+      {:error, reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: reason})
+    end
+  end
+
+  # Extract data from either uploaded file or request body
+  defp get_import_data(conn, params) do
+    cond do
+      # Check if there's a file upload
+      upload = params["file"] ->
+        handle_file_upload(upload)
+
+      # Check if there's a json_data parameter
+      json_data = params["json_data"] ->
+        {:ok, json_data, "json"}
+
+      # Check if there's a raw JSON body
+      true ->
+        case read_body(conn) do
+          {:ok, body, _} when body != "" ->
+            case Jason.decode(body) do
+              {:ok, _} -> {:ok, body, "json"} # Verify it's valid JSON
+              {:error, _} -> {:error, "Invalid JSON format in request body"}
+            end
+          _ ->
+            {:error, "No import data provided"}
+        end
+    end
+  end
+
+  defp handle_file_upload(%Plug.Upload{path: path, content_type: content_type, filename: filename}) do
+    cond do
+      # Handle JSON files
+      String.contains?(content_type, "json") || String.ends_with?(filename, ".json") ->
+        case File.read(path) do
+          {:ok, content} ->
+            # Just verify it's valid JSON, but keep the original string
+            case Jason.decode(content) do
+              {:ok, _} -> {:ok, content, "json"}
+              {:error, _} -> {:error, "Invalid JSON content in uploaded file"}
+            end
+          {:error, reason} -> {:error, "Failed to read uploaded file: #{inspect(reason)}"}
+        end
+
+      # Handle TSV files
+      String.contains?(content_type, "tab-separated-values") ||
+      String.ends_with?(filename, ".tsv") ||
+      String.ends_with?(filename, ".txt") ->
+        case File.read(path) do
+          {:ok, content} -> {:ok, content, "tsv"}
+          {:error, reason} -> {:error, "Failed to read uploaded file: #{inspect(reason)}"}
+        end
+
+      true ->
+        {:error, "File must be JSON or TSV format"}
+    end
+  end
+
+  defp handle_file_upload(_), do: {:error, "Invalid file upload"}
+end

--- a/server/lib/streamystat_server_web/controllers/playback_reporting_import_json.ex
+++ b/server/lib/streamystat_server_web/controllers/playback_reporting_import_json.ex
@@ -1,0 +1,12 @@
+defmodule StreamystatServerWeb.PlaybackReportingImportJSON do
+  @moduledoc """
+  JSON view for PlaybackReportingImportController responses.
+  """
+
+  def import(%{message: message, status: status}) do
+    %{
+      message: message,
+      status: status
+    }
+  end
+end

--- a/server/lib/streamystat_server_web/router.ex
+++ b/server/lib/streamystat_server_web/router.ex
@@ -45,6 +45,7 @@ defmodule StreamystatServerWeb.Router do
       get("/servers/:server_id/activities", ActivityController, :index)
       post("/servers/:server_id/tautulli/import", TautulliImportController, :import)
       post("/servers/:server_id/jellystats/import", JellystatsImportController, :import)
+      post("/servers/:server_id/playback-reporting/import", PlaybackReportingImportController, :import)
     end
 
     # Protected routes

--- a/server/priv/repo/migrations/20250420203410_remove_duplicate_playback_sessions.exs
+++ b/server/priv/repo/migrations/20250420203410_remove_duplicate_playback_sessions.exs
@@ -1,0 +1,40 @@
+defmodule StreamystatServer.Repo.Migrations.RemoveDuplicatePlaybackSessions do
+  use Ecto.Migration
+
+  def change do
+    # Create a temporary function to find duplicates and keep only the latest version
+    execute """
+    CREATE OR REPLACE FUNCTION deduplicate_playback_sessions() RETURNS void AS $$
+    DECLARE
+      duplicate_record RECORD;
+    BEGIN
+      FOR duplicate_record IN (
+        SELECT
+          item_jellyfin_id,
+          user_jellyfin_id,
+          start_time,
+          server_id,
+          COUNT(*) as count,
+          array_agg(id ORDER BY updated_at DESC) as ids
+        FROM
+          playback_sessions
+        GROUP BY
+          item_jellyfin_id, user_jellyfin_id, start_time, server_id
+        HAVING
+          COUNT(*) > 1
+      ) LOOP
+        -- Keep the first ID (most recently updated) and delete the rest
+        DELETE FROM playback_sessions
+        WHERE id = ANY(duplicate_record.ids[2:array_length(duplicate_record.ids, 1)]);
+      END LOOP;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    # Execute the function to deduplicate records
+    execute "SELECT deduplicate_playback_sessions();"
+
+    # Clean up - drop the temporary function
+    execute "DROP FUNCTION deduplicate_playback_sessions();"
+  end
+end

--- a/server/priv/repo/migrations/20250420203437_add_unique_index_to_playback_sessions.exs
+++ b/server/priv/repo/migrations/20250420203437_add_unique_index_to_playback_sessions.exs
@@ -1,0 +1,9 @@
+defmodule StreamystatServer.Repo.Migrations.AddUniqueIndexToPlaybackSessions do
+  use Ecto.Migration
+
+  def change do
+    # Create a unique index to prevent duplicate playback sessions
+    create unique_index(:playback_sessions, [:item_jellyfin_id, :user_jellyfin_id, :start_time, :server_id],
+      name: :playback_sessions_unique_index)
+  end
+end


### PR DESCRIPTION
- Settings upload form
- Backend worker to import data

## Summary by Sourcery

Add support for importing playback history from Jellyfin's Playback Reporting plugin

New Features:
- Implement import functionality for Playback Reporting plugin data in JSON and TSV formats
- Add a new import form in server settings for Playback Reporting data
- Create a backend worker to process and store imported playback sessions

Enhancements:
- Extend server settings page with an accordion-style import section
- Add flexible data import handling for different file formats
- Implement robust error handling and logging for import process