### PR TITLE
fix: container listening on 0.0.0.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /app
 # Set environment variables
 ENV NODE_ENV=production
 ENV NEXT_SHARP_PATH=/app/node_modules/sharp
+ENV HOSTNAME=0.0.0.0
 
 # Install production dependencies
 COPY package.json package-lock.json* ./


### PR DESCRIPTION
Build docker container to listen on all interfaces by default. Fixes #11 without the need to add the `HOSTNAME` variable to docker run / compose.

## Summary by Sourcery

Bug Fixes:
- Resolve issue with container network binding by setting HOSTNAME to 0.0.0.0 in the Dockerfile