### PR TITLE
fix: correct pluralization in 'No items watched yet' message in MostWatchedItems

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/dashboard/MostWatchedItems.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/dashboard/MostWatchedItems.tsx
@@ -66,7 +66,7 @@ export const MostWatchedItems: React.FC<Props> = ({ data, server }) => {
       <h2 className="text-xl font-bold mb-4">Most Watched {title}</h2>
       {items.length === 0 && (
         <p className="text-neutral-500">
-          No {type.toLowerCase()}s watched yet.
+          No {title.toLowerCase()} watched yet.
         </p>
       )}
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
This fixes situations where the user sees the text 'No seriess watched yet.'

## Summary by Sourcery

Bug Fixes:
- Correct the no-items-watched message to use the lowercased plural title instead of adding a trailing 's'.