### PR TITLE
fix phoenix/elixir container high memory usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       DATABASE_URL: "ecto://postgres:postgres@db/streamystat"
       SECRET_KEY_BASE: "r0NgGxu5ETTDgF5G7mJsMevMbAF7y4w0IJlCRjzxHqSjbcrPqTQTzajOH0ne0sHH"
     ulimits:
-      nofile: 1024
+      nofile:
+        soft: 65536
+        hard: 65536
     ports:
       - "4000:4000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     environment:
       DATABASE_URL: "ecto://postgres:postgres@db/streamystat"
       SECRET_KEY_BASE: "r0NgGxu5ETTDgF5G7mJsMevMbAF7y4w0IJlCRjzxHqSjbcrPqTQTzajOH0ne0sHH"
+    ulimits:
+      nofile: 1024
     ports:
       - "4000:4000"
     depends_on:


### PR DESCRIPTION
set hard/soft limit to number of files that can be opened at once from max value to 65536

## Summary by Sourcery

Constrain the Phoenix/Elixir application container’s open file descriptors to reduce resource usage

Bug Fixes:
- Set the maximum number of open files in the container to 1024 to prevent high memory usage

Deployment:
- Add `ulimits.nofile` configuration to the Docker Compose service