### PR TITLE
fix: save dismissed new version hash - don't show again

### DIFF
--- a/app/components/UpdateNotifier.tsx
+++ b/app/components/UpdateNotifier.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast, useSonner } from "sonner";
 
 interface VersionInfo {
@@ -11,60 +11,82 @@ interface VersionInfo {
 
 export function UpdateNotifier() {
   const { toasts } = useSonner();
-  const notifyUserOfUpdate = useCallback((newVersion: string) => {
-    if (toasts.find((t) => t.id === "update-notification")) {
-      return;
-    }
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 
-    toast.warning("New Version", {
-      id: "update-notification",
-      description: `A new version (${newVersion}) is available. Please update the docker images.`,
-      duration: Number.POSITIVE_INFINITY,
-      dismissible: true,
-      cancel: (
-        <button
-          className="shrink-0 ml-2 hover:opacity-50"
-          type="button"
-          onClick={() => toast.dismiss()}
-        >
-          Dismiss
-          <span className="sr-only">Dismiss</span>
-        </button>
-      ),
-      action: (
-        <button
-          type="button"
-          className="shrink-0 ml-2 hover:opacity-50 flex flex-row items-center gap-1"
-          onClick={() => {
-            // Go to latest release
-            window.open(
-              "https://github.com/fredrikburmester/streamystats/releases/latest",
-              "_blank"
-            );
-            toast.dismiss();
-          }}
-        >
-          Open
-          <span className="sr-only">Open</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="w-4 h-4"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-            />
-          </svg>
-        </button>
-      ),
-    });
+  // Load dismissed version from localStorage on mount
+  useEffect(() => {
+    const storedVersion = localStorage.getItem("dismissedUpdateVersion");
+    if (storedVersion) {
+      setDismissedVersion(storedVersion);
+    }
   }, []);
+
+  const notifyUserOfUpdate = useCallback(
+    (newVersion: string) => {
+      // Don't show notification if this version was already dismissed
+      if (
+        dismissedVersion === newVersion ||
+        toasts.find((t) => t.id === "update-notification")
+      ) {
+        return;
+      }
+
+      toast.warning("New Version", {
+        id: "update-notification",
+        description: `A new version (${newVersion}) is available. Please update the docker images.`,
+        duration: Number.POSITIVE_INFINITY,
+        dismissible: true,
+        cancel: (
+          <button
+            className="shrink-0 ml-2 hover:opacity-50"
+            type="button"
+            onClick={() => {
+              // Save the dismissed version to localStorage
+              localStorage.setItem("dismissedUpdateVersion", newVersion);
+              setDismissedVersion(newVersion);
+              toast.dismiss();
+            }}
+          >
+            Dismiss
+            <span className="sr-only">Dismiss</span>
+          </button>
+        ),
+        action: (
+          <button
+            type="button"
+            className="shrink-0 ml-2 hover:opacity-50 flex flex-row items-center gap-1"
+            onClick={() => {
+              // Go to latest release
+              window.open(
+                "https://github.com/fredrikburmester/streamystats/releases/latest",
+                "_blank"
+              );
+              toast.dismiss();
+            }}
+          >
+            Open
+            <span className="sr-only">Open</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-4 h-4"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+              />
+            </svg>
+          </button>
+        ),
+      });
+    },
+    [dismissedVersion, toasts]
+  );
 
   useEffect(() => {
     // biome-ignore lint/style/useConst: <explanation>
@@ -76,7 +98,10 @@ export function UpdateNotifier() {
         const response = await fetch("/api/version");
         const versionInfo: VersionInfo = await response.json();
 
-        if (versionInfo.hasUpdate) {
+        if (
+          versionInfo.hasUpdate &&
+          versionInfo.latestVersion !== dismissedVersion
+        ) {
           notifyUserOfUpdate(versionInfo.latestVersion);
         }
       } catch (error) {
@@ -91,7 +116,7 @@ export function UpdateNotifier() {
     setTimeout(checkForUpdates, 1000);
 
     return () => clearInterval(intervalId);
-  }, [notifyUserOfUpdate]);
+  }, [notifyUserOfUpdate, dismissedVersion]);
 
   return null;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - backend
 
   db:
-    image: tensorchord/pgvecto-rs:pg16-v0.4.0
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/server/priv/repo/migrations/20250428183624_add_pgvector_extension.exs
+++ b/server/priv/repo/migrations/20250428183624_add_pgvector_extension.exs
@@ -2,6 +2,6 @@ defmodule StreamystatServer.Repo.Migrations.AddPgvectorExtension do
   use Ecto.Migration
 
   def change do
-    execute("CREATE EXTENSION IF NOT EXISTS vectors")
+    execute("CREATE EXTENSION IF NOT EXISTS vector")
   end
 end


### PR DESCRIPTION
## Summary by Sourcery

Persist dismissed update notifications to prevent re-showing the same version once dismissed.

Enhancements:
- Add state and localStorage integration to store and load the dismissed update version.
- Enhance notification logic to skip showing toasts for versions that have been previously dismissed.