### PR TITLE
fix: embedding count when server restarts

### DIFF
--- a/server/lib/streamystat_server_web/controllers/server_controller.ex
+++ b/server/lib/streamystat_server_web/controllers/server_controller.ex
@@ -1,5 +1,6 @@
 defmodule StreamystatServerWeb.ServerController do
   use StreamystatServerWeb, :controller
+  import Ecto.Query
   alias StreamystatServer.Servers.Servers
   alias StreamystatServer.Servers.Models.Server
   alias StreamystatServer.BatchEmbedder


### PR DESCRIPTION
## Summary by Sourcery

Fix embedding progress reporting by querying actual counts from the database when in-memory state is missing and update progress correctly after clearing embeddings.

Bug Fixes:
- Retrieve actual total and processed embedding counts from the database when no in-memory progress exists to prevent stale or zeroed progress on server restart
- Update progress tracker with the correct total count after clearing embeddings instead of resetting both values to zero