### PR TITLE
fix: streamystats db import in settings

### DIFF
--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -74,7 +74,7 @@ config :streamystat_server, dev_routes: true
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,
   format: "$time [$level] $message\n",
-  level: :info
+  level: :debug
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/server/lib/streamystat_server/sessions/models/playback_session.ex
+++ b/server/lib/streamystat_server/sessions/models/playback_session.ex
@@ -74,7 +74,6 @@ defmodule StreamystatServer.Sessions.Models.PlaybackSession do
     field(:percent_complete, :float)
     field(:completed, :boolean)
 
-    # New PlayState fields
     field(:is_paused, :boolean)
     field(:is_muted, :boolean)
     field(:volume_level, :integer)
@@ -84,9 +83,7 @@ defmodule StreamystatServer.Sessions.Models.PlaybackSession do
     field(:repeat_mode, :string)
     field(:playback_order, :string)
 
-    # New Session fields
     field(:remote_end_point, :string)
-    # This maps to "Id" in the Session object
     field(:session_id, :string)
     field(:user_name, :string)
     field(:last_activity_date, :utc_datetime)
@@ -94,7 +91,6 @@ defmodule StreamystatServer.Sessions.Models.PlaybackSession do
     field(:application_version, :string)
     field(:is_active, :boolean)
 
-    # Transcoding info fields
     field(:transcoding_audio_codec, :string)
     field(:transcoding_video_codec, :string)
     field(:transcoding_container, :string)
@@ -136,7 +132,6 @@ defmodule StreamystatServer.Sessions.Models.PlaybackSession do
       :completed,
       :user_id,
       :server_id,
-      # New fields
       :is_paused,
       :is_muted,
       :volume_level,

--- a/server/lib/streamystat_server_web/controllers/backup_controller.ex
+++ b/server/lib/streamystat_server_web/controllers/backup_controller.ex
@@ -135,7 +135,6 @@ defmodule StreamystatServerWeb.BackupController do
       runtime_ticks INTEGER,
       percent_complete FLOAT,
       completed BOOLEAN,
-      server_id INTEGER,
       inserted_at TEXT,
       updated_at TEXT
     )
@@ -153,8 +152,8 @@ defmodule StreamystatServerWeb.BackupController do
       item_jellyfin_id, item_name, series_jellyfin_id, series_name,
       season_jellyfin_id, play_duration, play_method, start_time,
       end_time, position_ticks, runtime_ticks, percent_complete,
-      completed, server_id, inserted_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      completed, inserted_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """)
   end
 
@@ -196,7 +195,6 @@ defmodule StreamystatServerWeb.BackupController do
       session.runtime_ticks,
       session.percent_complete,
       session.completed,
-      session.server_id,
       NaiveDateTime.to_iso8601(session.inserted_at),
       NaiveDateTime.to_iso8601(session.updated_at)
     ]
@@ -209,87 +207,433 @@ defmodule StreamystatServerWeb.BackupController do
     end
   end
 
-  def import(conn, %{"server_id" => server_id_str, "file" => %Plug.Upload{path: path}}) do
+  def import(conn, %{"server_id" => server_id_str, "file" => %Plug.Upload{path: path} = upload}) do
     server_id = String.to_integer(server_id_str)
+    Logger.info("Starting import from file: #{upload.filename}, size: #{File.stat!(path).size} bytes")
 
     case Repo.get(Server, server_id) do
       nil ->
+        Logger.error("Import failed: Server with ID #{server_id} not found")
         conn |> put_status(:not_found) |> json(%{error: "Server not found"})
 
-      _ ->
+      server ->
+        Logger.info("Importing playback sessions for server: #{server.name} (ID: #{server_id})")
         case process_import(path, server_id) do
           {:ok, count} ->
+            Logger.info("Import successful: #{count} playback sessions imported")
             json(conn, %{message: "Successfully imported #{count} playback sessions"})
 
+          {:partial, imported, skipped, reason} ->
+            # Partial success - some records imported, some failed
+            message = "Partially imported #{imported} playback sessions (#{skipped} skipped): #{reason}"
+            Logger.warn(message)
+            conn |> put_status(:partial_content) |> json(%{
+              message: message,
+              imported: imported,
+              skipped: skipped
+            })
+
           {:error, reason} ->
+            Logger.error("Import failed with error: #{inspect(reason)}")
             conn |> put_status(:bad_request) |> json(%{error: reason})
         end
     end
   end
 
   defp process_import(file_path, server_id) do
-    with :ok <- verify_file_exists(file_path),
-         {:ok, db} <- Exqlite.Sqlite3.open(file_path, mode: :readonly),
-         {:ok, table_name} <- find_playback_sessions_table(db),
-         {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT * FROM #{table_name}"),
-         {:ok, cols} <- Exqlite.Sqlite3.columns(db, stmt),
-         rows <- fetch_all_rows(db, stmt),
-         :ok <- cleanup_db_resources(db, stmt) do
+    Logger.debug("Starting import process for file: #{file_path}")
 
-      process_import_batches(rows, cols, server_id)
+    with {:ok, file_stat} <- File.stat(file_path),
+         :ok <- verify_file_size(file_stat),
+         :ok <- verify_file_exists(file_path),
+         {:ok, db} <- open_sqlite_db(file_path),
+         {:ok, table_name} <- find_playback_sessions_table(db) do
+
+      # Prepare the statement using the table name
+      prepare_result = prepare_statement(db, table_name)
+
+      case prepare_result do
+        {:ok, stmt} ->
+          process_with_statement(db, stmt, server_id)
+
+        {:error, reason} ->
+          Logger.error("Failed to prepare statement: #{inspect(reason)}")
+          {:error, "Failed to prepare SQL statement: #{inspect(reason)}"}
+      end
     else
-      {:error, reason} -> {:error, reason}
-      e -> {:error, "Import failed: #{Exception.message(e)}"}
+      {:error, reason} ->
+        Logger.error("Import process error: #{inspect(reason)}")
+        {:error, reason}
+      :ok ->
+        Logger.error("Unexpected :ok response during import")
+        {:error, "Unexpected response during import process"}
+      other ->
+        Logger.error("Unexpected error during import: #{inspect(other)}")
+        error_msg = try do
+          "Import failed: #{Exception.message(other)}"
+        rescue
+          # Handle case where other isn't an exception
+          _ -> "Import failed: unexpected error (#{inspect(other)})"
+        end
+        {:error, error_msg}
     end
+  end
+
+  defp process_with_statement(db, stmt, server_id) do
+    # First try to get columns through standard method
+    columns_result = get_columns(db, stmt)
+
+    case columns_result do
+      {:ok, cols} ->
+        Logger.debug("Got columns for prepared statement: #{inspect(cols)}")
+        # Get the rows and proceed with import
+        with rows when is_list(rows) <- fetch_all_rows(db, stmt),
+             :ok <- cleanup_db_resources(db, stmt) do
+
+          Logger.debug("Successfully read #{length(rows)} rows from import file")
+          process_import_batches(rows, cols, server_id)
+        else
+          error ->
+            Logger.error("Failed to fetch rows: #{inspect(error)}")
+            cleanup_db_resources(db, stmt)
+            {:error, "Failed to read rows from database"}
+        end
+
+      {:error, reason} ->
+        Logger.error("Failed to get columns: #{inspect(reason)}")
+        cleanup_db_resources(db, stmt)
+        {:error, "Failed to get column information: #{inspect(reason)}"}
+
+      unexpected ->
+        Logger.error("Unexpected result getting columns: #{inspect(unexpected)}")
+        cleanup_db_resources(db, stmt)
+        {:error, "Unexpected error getting column information"}
+    end
+  end
+
+  defp verify_file_size(%{size: size}) do
+    case size do
+      0 -> {:error, "Import file is empty"}
+      _ -> :ok
+    end
+  end
+
+    defp open_sqlite_db(file_path) do
+    try do
+      Logger.debug("Opening SQLite database: #{file_path}")
+
+      # Check if the file appears to be a valid SQLite file
+      validate_sqlite_file(file_path)
+
+      case Exqlite.Sqlite3.open(file_path, mode: :readonly) do
+        {:ok, db} ->
+          # Try to read SQLite version to verify connection
+          case Exqlite.Sqlite3.execute(db, "SELECT sqlite_version()") do
+            {:ok, [[version]]} ->
+              Logger.debug("Connected to SQLite database, version: #{version}")
+              {:ok, db}
+            _ ->
+              Logger.debug("Connected to SQLite database, but couldn't verify version")
+              {:ok, db}
+          end
+        other -> other
+      end
+    rescue
+      e ->
+        Logger.error("Failed to open SQLite database: #{Exception.message(e)}")
+        {:error, "Failed to open database file, it may be corrupted or not a valid SQLite file"}
+    end
+  end
+
+  defp validate_sqlite_file(file_path) do
+    # Check the file signature (SQLite files start with "SQLite format 3\000")
+    case File.open(file_path, [:read]) do
+      {:ok, file} ->
+        case :file.read(file, 16) do
+          {:ok, "SQLite format 3" <> _} ->
+            Logger.debug("File has valid SQLite header signature")
+            File.close(file)
+            :ok
+          {:ok, other} ->
+            Logger.error("Invalid SQLite file signature: #{inspect(other)}")
+            File.close(file)
+            :ok  # Still return ok to continue with more detailed diagnostics
+          error ->
+            Logger.error("Error reading SQLite file header: #{inspect(error)}")
+            File.close(file)
+            :ok  # Still return ok to continue with normal import flow
+        end
+      error ->
+        Logger.error("Could not open file for header check: #{inspect(error)}")
+        :ok  # Still return ok to allow normal import flow to handle errors
+    end
+  end
+
+  defp prepare_statement(db, table_name) do
+    Logger.debug("Preparing statement for table: #{table_name}")
+    query = "SELECT * FROM #{table_name}"
+    Exqlite.Sqlite3.prepare(db, query)
+  end
+
+  defp get_columns(db, stmt) do
+    Logger.debug("Getting columns for prepared statement")
+    Exqlite.Sqlite3.columns(db, stmt)
   end
 
   defp verify_file_exists(file_path) do
     if File.exists?(file_path), do: :ok, else: {:error, "Database file not found: #{file_path}"}
   end
 
-  defp find_playback_sessions_table(db) do
+    defp find_playback_sessions_table(db) do
+    Logger.debug("Looking for playback_sessions table in the database file")
+
+    # Try multiple approaches to find tables
+    try_direct_table_access(db)
+  end
+
+  defp try_direct_table_access(db) do
+    # First try: Standard approach with sqlite_master
+    master_query_result = Exqlite.Sqlite3.execute(db, "SELECT name FROM sqlite_master WHERE type='table'")
+    Logger.debug("sqlite_master query result: #{inspect(master_query_result)}")
+
+    # Second try: Attempt to directly access the playback_sessions table
+    Logger.debug("Attempting direct access to playback_sessions table")
+    direct_result = Exqlite.Sqlite3.execute(db, "SELECT 1 FROM playback_sessions LIMIT 1")
+    Logger.debug("Direct table access result: #{inspect(direct_result)}")
+
+    # Based on the results, determine the best course of action
+    cond do
+      # If master query found tables, use that
+      match?({:ok, tables} when is_list(tables) and length(tables) > 0, master_query_result) ->
+        {:ok, tables} = master_query_result
+        Logger.debug("Found tables in database via sqlite_master: #{inspect(tables)}")
+        search_for_playback_table(db, tables)
+
+      # If direct access to playback_sessions worked
+      match?({:ok, _}, direct_result) or direct_result == :ok ->
+        Logger.debug("Direct access to playback_sessions table succeeded")
+        # Verify we can get column info
+        case Exqlite.Sqlite3.execute(db, "PRAGMA table_info(playback_sessions)") do
+          {:ok, columns} when is_list(columns) ->
+            Logger.debug("Found playback_sessions table with columns via direct access")
+            {:ok, "playback_sessions"}
+          other ->
+            Logger.debug("Direct access succeeded but couldn't get column info: #{inspect(other)}")
+            {:ok, "playback_sessions"} # Still proceed since we know table exists
+        end
+
+      # Try to diagnose other database issues
+      true ->
+        diagnose_database_issues(db, master_query_result, direct_result)
+    end
+  end
+
+  defp diagnose_database_issues(db, master_query_result, direct_result) do
+    # Log detailed diagnostic information
+    Logger.error("Could not find tables via standard methods")
+    Logger.error("sqlite_master query result: #{inspect(master_query_result)}")
+    Logger.error("Direct table access result: #{inspect(direct_result)}")
+
+    # Try to get database information via PRAGMA statements
+    pragma_results = %{
+      integrity_check: Exqlite.Sqlite3.execute(db, "PRAGMA integrity_check"),
+      foreign_keys: Exqlite.Sqlite3.execute(db, "PRAGMA foreign_keys"),
+      journal_mode: Exqlite.Sqlite3.execute(db, "PRAGMA journal_mode"),
+      synchronous: Exqlite.Sqlite3.execute(db, "PRAGMA synchronous")
+    }
+
+    Logger.debug("PRAGMA diagnostics: #{inspect(pragma_results)}")
+
+    # If direct access failed with specific errors, provide those messages
+    cond do
+      match?({:error, reason}, direct_result) ->
+        Logger.error("Direct access to playback_sessions table failed: #{inspect(direct_result)}")
+        {:error, "Could not access playback_sessions table: #{inspect(direct_result)}"}
+
+      match?({:error, reason}, master_query_result) ->
+        Logger.error("SQLite master table query failed: #{inspect(master_query_result)}")
+        {:error, "Database structure query failed: #{inspect(master_query_result)}"}
+
+      true ->
+        # Last resort, assume it's a different issue
+        Logger.error("No tables found in the database file or unexpected database structure")
+        {:error, "The database file appears valid but no tables could be found or accessed"}
+    end
+  end
+
+  defp search_for_playback_table(db, tables) do
     case Exqlite.Sqlite3.execute(db, "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%playback_sessions%'") do
-      {:ok, []} -> {:error, "No playback sessions table found in database"}
-      {:ok, [[table_name]]} -> {:ok, table_name}
-      error -> error
+      {:ok, []} ->
+        Logger.error("No playback_sessions table found in the database")
+        {:error, "No playback sessions table found in database. Available tables: #{inspect(tables)}"}
+
+      :ok ->
+        # :ok means success but empty result
+        Logger.error("No playback_sessions table found in the database")
+        {:error, "No playback sessions table found in database. Available tables: #{inspect(tables)}"}
+
+      {:ok, [[table_name]]} ->
+        # Check if the table has the expected structure
+        validate_table_structure(db, table_name, tables)
+
+      {:error, reason} ->
+        Logger.error("Error looking for playback_sessions table: #{inspect(reason)}")
+        {:error, "Error searching for playback sessions table: #{inspect(reason)}"}
+
+      unexpected ->
+        Logger.error("Unexpected result when looking for playback_sessions table: #{inspect(unexpected)}")
+        {:error, "Unexpected result when searching for playback sessions table"}
+    end
+  end
+
+  defp validate_table_structure(db, table_name, all_tables) do
+    # Check if the table has the minimum required columns
+    case Exqlite.Sqlite3.execute(db, "PRAGMA table_info(#{table_name})") do
+      {:ok, columns} when is_list(columns) ->
+        column_names = Enum.map(columns, fn column -> Enum.at(column, 1) end)
+        Logger.debug("Found columns in table #{table_name}: #{inspect(column_names)}")
+
+        required_columns = ["id", "user_jellyfin_id", "item_jellyfin_id", "play_duration"]
+        missing_columns = Enum.filter(required_columns, fn col -> col not in column_names end)
+
+        if Enum.empty?(missing_columns) do
+          Logger.debug("Table #{table_name} has all required columns")
+          {:ok, table_name}
+        else
+          Logger.error("Table #{table_name} is missing required columns: #{inspect(missing_columns)}")
+          {:error, "The playback_sessions table is missing required columns: #{inspect(missing_columns)}"}
+        end
+
+      :ok ->
+        Logger.error("Failed to get column info for table #{table_name}")
+        {:error, "Failed to get column information for playback_sessions table"}
+
+      {:error, reason} ->
+        Logger.error("Error getting column info for table #{table_name}: #{inspect(reason)}")
+        {:error, "Failed to validate table structure: #{inspect(reason)}"}
+
+      unexpected ->
+        Logger.error("Unexpected result when getting column info: #{inspect(unexpected)}")
+        {:error, "Failed to validate table structure due to unexpected error"}
     end
   end
 
   defp fetch_all_rows(db, stmt) do
-    rows = []
-    case Exqlite.Sqlite3.step(db, stmt) do
-      {:row, row} -> fetch_all_rows(db, stmt, [row | rows])
-      :done -> Enum.reverse(rows)
-      error -> error
+    Logger.debug("Starting to fetch rows from database")
+    try do
+      rows = []
+      result = fetch_all_rows(db, stmt, rows, 0)
+      Logger.debug("Finished fetching rows: #{inspect(result)}")
+      result
+    rescue
+      e ->
+        error_message = "Error starting row fetch: #{Exception.message(e)}"
+        Logger.error(error_message)
+        {:error, error_message}
     end
   end
 
-  defp fetch_all_rows(db, stmt, rows) do
-    case Exqlite.Sqlite3.step(db, stmt) do
-      {:row, row} -> fetch_all_rows(db, stmt, [row | rows])
-      :done -> Enum.reverse(rows)
-      error -> error
+  defp fetch_all_rows(db, stmt, rows, count) do
+    try do
+      case Exqlite.Sqlite3.step(db, stmt) do
+        {:row, row} ->
+          # Log progress for large imports
+          new_count = count + 1
+          if rem(new_count, 1000) == 0 do
+            Logger.debug("Fetched #{new_count} rows so far")
+          end
+          fetch_all_rows(db, stmt, [row | rows], new_count)
+        :done ->
+          Logger.debug("Done fetching all rows. Total: #{count}")
+          Enum.reverse(rows)
+        {:error, reason} ->
+          Logger.error("Error fetching rows at row #{count}: #{inspect(reason)}")
+          {:error, reason}
+        unexpected ->
+          Logger.error("Unexpected response from database at row #{count}: #{inspect(unexpected)}")
+          {:error, "Unexpected response from database: #{inspect(unexpected)}"}
+      end
+    rescue
+      e ->
+        error_message = "Error during row fetch at row #{count}: #{Exception.message(e)}"
+        Logger.error(error_message)
+        {:error, error_message}
     end
   end
 
   defp cleanup_db_resources(db, stmt) do
-    :ok = Exqlite.Sqlite3.release(db, stmt)
-    :ok = Exqlite.Sqlite3.close(db)
+    # Release the statement
+    release_result = try do
+      Exqlite.Sqlite3.release(db, stmt)
+    rescue
+      _ -> :error
+    end
+
+    # Close the database
+    close_result = try do
+      Exqlite.Sqlite3.close(db)
+    rescue
+      _ -> :error
+    end
+
+    # Log any errors but always return :ok to not disrupt the flow
+    case {release_result, close_result} do
+      {:ok, :ok} -> :ok
+      {release_result, close_result} ->
+        Logger.error("Error during cleanup: release=#{inspect(release_result)}, close=#{inspect(close_result)}")
+        :ok
+    end
   end
 
   defp process_import_batches(rows, cols, server_id) do
     # Convert column names to atoms for easier access
     col_atoms = Enum.map(cols, &String.to_atom/1)
 
+    # Track statistics
+    stats = %{imported: 0, skipped: 0, errors: 0}
+
     # Process rows in batches
-    rows
+    result = rows
     |> Enum.chunk_every(@batch_size)
-    |> Enum.reduce_while({:ok, 0}, fn batch, {:ok, count} ->
+    |> Enum.reduce_while({:ok, stats}, fn batch, {:ok, stats} ->
       case process_batch(batch, col_atoms, server_id) do
-        {:ok, batch_count} -> {:cont, {:ok, count + batch_count}}
-        {:error, reason} -> {:halt, {:error, reason}}
+        {:ok, batch_stats} ->
+          new_stats = %{
+            imported: stats.imported + batch_stats.imported,
+            skipped: stats.skipped + batch_stats.skipped,
+            errors: stats.errors + batch_stats.errors
+          }
+          {:cont, {:ok, new_stats}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason, stats}}
       end
     end)
+
+    case result do
+      {:ok, stats} ->
+        total = stats.imported + stats.skipped
+        skipped_percent = if total > 0, do: Float.round(stats.skipped / total * 100, 1), else: 0
+
+        if stats.skipped > 0 do
+          Logger.info("Import completed with #{stats.imported} records imported, #{stats.skipped} skipped (#{skipped_percent}%)")
+
+          if stats.imported > 0 do
+            {:partial, stats.imported, stats.skipped, "Some records already existed"}
+          else
+            {:error, "All records already exist in the database (#{stats.skipped} duplicates)"}
+          end
+        else
+          {:ok, stats.imported}
+        end
+
+      {:error, reason, stats} ->
+        if stats.imported > 0 do
+          {:partial, stats.imported, stats.skipped, reason}
+        else
+          {:error, reason}
+        end
+    end
   end
 
   defp process_batch(rows, col_atoms, server_id) do
@@ -298,54 +642,93 @@ defmodule StreamystatServerWeb.BackupController do
       Enum.zip(col_atoms, row) |> Map.new()
     end)
 
-    # Insert sessions in a transaction
+    # Track import statistics for this batch
+    batch_stats = %{imported: 0, skipped: 0, errors: 0}
+
+    # Insert sessions in a transaction with conflict handling
     case Repo.transaction(fn ->
-      Enum.reduce_while(sessions, {:ok, 0}, fn session, {:ok, count} ->
-        case create_session(session, server_id) do
-          {:ok, _} -> {:cont, {:ok, count + 1}}
-          {:error, reason} -> {:halt, {:error, reason}}
+      Enum.reduce_while(sessions, {:ok, batch_stats}, fn session, {:ok, stats} ->
+        case import_session(session, server_id) do
+          {:ok, _} ->
+            {:cont, {:ok, %{stats | imported: stats.imported + 1}}}
+
+          {:skipped, :duplicate} ->
+            {:cont, {:ok, %{stats | skipped: stats.skipped + 1}}}
+
+          {:error, %Ecto.Changeset{errors: errors}} = error ->
+            if is_duplicate_error?(errors) do
+              # Skip duplicates and continue
+              Logger.debug("Skipping duplicate record with ID: #{session.id}")
+              {:cont, {:ok, %{stats | skipped: stats.skipped + 1}}}
+            else
+              # For other errors, halt the process
+              Logger.error("Error importing session: #{inspect(error)}")
+              {:halt, {:error, "Failed to import record: #{inspect(errors)}", stats}}
+            end
+
+          {:error, reason} ->
+            Logger.error("Error importing session: #{inspect(reason)}")
+            stats = %{stats | errors: stats.errors + 1}
+            {:halt, {:error, reason, stats}}
         end
       end)
     end) do
-      {:ok, {:ok, count}} -> {:ok, count}
-      {:ok, {:error, reason}} -> {:error, reason}
+      {:ok, {:ok, stats}} -> {:ok, stats}
+      {:ok, {:error, reason, stats}} -> {:error, reason, stats}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp create_session(session, server_id) do
-    # Convert string timestamps to DateTime
-    start_time = parse_datetime(session.start_time)
-    end_time = parse_datetime(session.end_time)
-    inserted_at = parse_datetime(session.inserted_at)
-    updated_at = parse_datetime(session.updated_at)
+  defp import_session(session, server_id) do
+    # Try to get existing session with same ID
+    case Repo.get(PlaybackSession, session.id) do
+      %PlaybackSession{} = existing ->
+        Logger.debug("Found existing session with ID #{session.id}, skipping")
+        {:skipped, :duplicate}
 
-    # Create session with converted timestamps
-    %PlaybackSession{}
-    |> PlaybackSession.changeset(%{
-      id: session.id,
-      user_jellyfin_id: session.user_jellyfin_id,
-      device_id: session.device_id,
-      device_name: session.device_name,
-      client_name: session.client_name,
-      item_jellyfin_id: session.item_jellyfin_id,
-      item_name: session.item_name,
-      series_jellyfin_id: session.series_jellyfin_id,
-      series_name: session.series_name,
-      season_jellyfin_id: session.season_jellyfin_id,
-      play_duration: session.play_duration,
-      play_method: session.play_method,
-      start_time: start_time,
-      end_time: end_time,
-      position_ticks: session.position_ticks,
-      runtime_ticks: session.runtime_ticks,
-      percent_complete: session.percent_complete,
-      completed: parse_bool(session.completed),
-      server_id: server_id,
-      inserted_at: inserted_at,
-      updated_at: updated_at
-    })
-    |> Repo.insert()
+      nil ->
+        # Convert string timestamps to DateTime
+        start_time = parse_datetime(session.start_time)
+        end_time = parse_datetime(session.end_time)
+        inserted_at = parse_datetime(session.inserted_at)
+        updated_at = parse_datetime(session.updated_at)
+
+        # Create session with converted timestamps
+        %PlaybackSession{}
+        |> PlaybackSession.changeset(%{
+          id: session.id,
+          user_jellyfin_id: session.user_jellyfin_id,
+          device_id: session.device_id,
+          device_name: session.device_name,
+          client_name: session.client_name,
+          item_jellyfin_id: session.item_jellyfin_id,
+          item_name: session.item_name,
+          series_jellyfin_id: session.series_jellyfin_id,
+          series_name: session.series_name,
+          season_jellyfin_id: session.season_jellyfin_id,
+          play_duration: session.play_duration,
+          play_method: session.play_method,
+          start_time: start_time,
+          end_time: end_time,
+          position_ticks: session.position_ticks,
+          runtime_ticks: session.runtime_ticks,
+          percent_complete: session.percent_complete,
+          completed: parse_bool(session.completed),
+          server_id: server_id,
+          inserted_at: inserted_at,
+          updated_at: updated_at
+        })
+        |> Repo.insert()
+    end
+  end
+
+  defp is_duplicate_error?(errors) do
+    Enum.any?(errors, fn {field, {message, details}} ->
+      message =~ "has already been taken" or
+      (details[:constraint] == "unique" or details[:constraint] == "primary") or
+      details[:constraint] == "playback_sessions_unique_index" or
+      details[:constraint] =~ "unique"
+    end)
   end
 
   defp parse_datetime(nil), do: nil


### PR DESCRIPTION
## Summary by Sourcery

Overhaul the settings import workflow to remove a deprecated column, add robust validation, logging, and error handling, and support partial playback session imports with batch statistics

Enhancements:
- Remove server_id column from import table schema and queries
- Add detailed logging throughout the import process and set dev log level to debug
- Validate import file size and SQLite header before opening the database
- Refactor import pipeline to prepare SQL statements, detect table structure, fetch rows with progress logs, and clean up resources
- Enhance batch import to accumulate statistics and return partial successes with skipped duplicate handling

Chores:
- Clean up commented-out fields in PlaybackSession schema