### PR TITLE
fix: zombie process

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update -y && \
   apt-get install -y --no-install-recommends libncurses5 && \
   apt-get install -y --no-install-recommends locales && \
   apt-get install -y --no-install-recommends postgresql-client && \
+  apt-get install -y --no-install-recommends tini && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -103,9 +104,5 @@ RUN chmod +x /server/entrypoint.sh
 
 USER nobody
 
-# If using an environment that doesn't automatically reap zombie processes, it is
-# advised to add an init process such as tini via `apt-get install`
-# above and adding an entrypoint. See https://github.com/krallin/tini for details
-# ENTRYPOINT ["/tini", "--"]
-
-ENTRYPOINT ["sh", "/server/entrypoint.sh"]
+# Using tini as the init process to reap zombie processes
+ENTRYPOINT ["/usr/bin/tini", "--", "/server/entrypoint.sh"]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -14,7 +14,7 @@ do
   sleep 2
 done
 
-# Check if the database exists, create it if it doesn’t
+# Check if the database exists, create it if it doesn't
 if ! PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -lqt | cut -d \| -f 1 | grep -qw $DB_NAME; then
   echo "Database $DB_NAME does not exist. Creating..."
   PGPASSWORD=$DB_PASSWORD createdb -h $DB_HOST -U $DB_USER $DB_NAME
@@ -23,4 +23,5 @@ fi
 
 /server/bin/streamystat_server eval "StreamystatServer.Release.migrate"
 
-exec /server/bin/server
+# Execute the server process as the main process (PID 1)
+exec /server/bin/streamystat_server start


### PR DESCRIPTION
## Summary by Sourcery

Introduce tini as the init process in the Docker container to reap zombie processes and update the entrypoint script to correctly exec the server with its start command.

Bug Fixes:
- Reap zombie processes by installing and using tini as the init process in the container

Enhancements:
- Install tini in the Dockerfile and streamline the entrypoint to exec the server with `streamystat_server start`
- Correct a comment typo in the entrypoint script