### PR TITLE
fix: refactor settings page and sidebar

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/settings/DatabaseBackupRestore.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/DatabaseBackupRestore.tsx
@@ -83,16 +83,16 @@ export default function DatabaseBackupRestore({
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Database Backup & Restore</CardTitle>
+          <CardTitle>Streamystats Backup & Restore</CardTitle>
           <CardDescription>
-            Export or restore your playback session data
+            Export or restore your <b>playback session data</b>
           </CardDescription>
         </CardHeader>
 
         <CardContent className="space-y-6">
           {/* EXPORT */}
           <div className="space-y-2">
-            <h3 className="text-lg font-medium">Export Sessions</h3>
+            <h3 className="">Export Sessions</h3>
             {exportMutation.isError && (
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
@@ -110,13 +110,13 @@ export default function DatabaseBackupRestore({
               className="flex items-center gap-2"
             >
               <Download className="h-4 w-4" />
-              {exportMutation.isPending ? "Exporting..." : "Export Database"}
+              {exportMutation.isPending ? "Downloading..." : "Download"}
             </Button>
           </div>
 
           {/* IMPORT */}
           <div className="space-y-2">
-            <h3 className="text-lg font-medium">Import Sessions</h3>
+            <h3 className="">Import Sessions</h3>
             {importMutation.isError && (
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
@@ -142,7 +142,9 @@ export default function DatabaseBackupRestore({
                 className="flex items-center gap-2"
               >
                 <Upload className="h-4 w-4" />
-                {importMutation.isPending ? "Importing..." : "Import Database"}
+                {importMutation.isPending
+                  ? "Uploading..."
+                  : "Upload and Import"}
               </Button>
             </div>
           </div>

--- a/app/app/(app)/servers/[id]/(auth)/settings/JellystatsImport.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/JellystatsImport.tsx
@@ -93,7 +93,10 @@ export default function JellystatsImport({ serverId }: { serverId: number }) {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form action={formAction} className="space-y-4">
+        <form
+          action={formAction}
+          className="space-y-4 flex flex-col items-start"
+        >
           {/* Hidden input for server ID */}
           <input type="hidden" name="serverId" value={serverId} />
 
@@ -131,8 +134,7 @@ export default function JellystatsImport({ serverId }: { serverId: number }) {
               <AlertDescription>{state.message}</AlertDescription>
             </Alert>
           )}
-
-          <div className="pt-2">
+          <div className="flex flex-col items-start justify-start">
             <SubmitButton hasFile={!!selectedFile} />
           </div>
         </form>

--- a/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/PlaybackReportingImport.tsx
@@ -106,7 +106,10 @@ export default function PlaybackReportingImport({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form action={formAction} className="space-y-4">
+        <form
+          action={formAction}
+          className="space-y-4 flex flex-col items-start"
+        >
           {/* Hidden input for server ID */}
           <input type="hidden" name="serverId" value={serverId} />
 
@@ -148,7 +151,7 @@ export default function PlaybackReportingImport({
             </Alert>
           )}
 
-          <div className="pt-2">
+          <div className="flex flex-col items-start justify-start">
             <SubmitButton hasFile={!!selectedFile} />
           </div>
         </form>

--- a/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/settings/page.tsx
@@ -26,8 +26,10 @@ import {
 
 export default async function Settings({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: { section?: string };
 }) {
   const { id } = await params;
   const server = await getServer(id);
@@ -35,40 +37,46 @@ export default async function Settings({
     redirect("/setup");
   }
 
+  const section = searchParams.section || "general";
+
   return (
     <Container className="">
       <h1 className="text-3xl font-bold mb-8">Settings</h1>
-      <Tasks server={server} />
-      <EmbeddingsManager server={server} />
-      <Accordion type="single" collapsible className="mb-4">
-        <AccordionItem value="jellystat-import">
-          <AccordionTrigger className="text-2xl font-semibold">
-            Jellystat Import
-          </AccordionTrigger>
-          <AccordionContent>
-            <JellystatsImport serverId={server.id} />
-          </AccordionContent>
-        </AccordionItem>
-        <AccordionItem value="playback-reporting-import">
-          <AccordionTrigger className="text-2xl font-semibold">
-            Playback Reporting Plugin Import
-          </AccordionTrigger>
-          <AccordionContent>
-            <PlaybackReportingImport serverId={server.id} />
-          </AccordionContent>
-        </AccordionItem>
-        <AccordionItem value="database-backup">
-          <AccordionTrigger className="text-2xl font-semibold">
-            Database Backup & Restore
-          </AccordionTrigger>
-          <AccordionContent>
-            <DatabaseBackupRestore serverId={server.id} />
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
 
-      <VersionSection />
-      <DeleteServer server={server} />
+      {section === "general" && (
+        <div className="space-y-8">
+          <VersionSection />
+          <DeleteServer server={server} />
+        </div>
+      )}
+
+      {section === "sync" && (
+        <div className="space-y-8">
+          <Tasks server={server} />
+        </div>
+      )}
+
+      {section === "ai" && (
+        <div className="space-y-8">
+          <EmbeddingsManager server={server} />
+        </div>
+      )}
+
+      {section === "backup" && (
+        <div className="space-y-8">
+          <div>
+            <DatabaseBackupRestore serverId={server.id} />
+          </div>
+
+          <div>
+            <JellystatsImport serverId={server.id} />
+          </div>
+
+          <div>
+            <PlaybackReportingImport serverId={server.id} />
+          </div>
+        </div>
+      )}
     </Container>
   );
 }

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -29,7 +29,15 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from "./ui/sidebar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
 
 const admin_items = [
   {
@@ -47,10 +55,28 @@ const admin_items = [
     url: "/users",
     icon: Users,
   },
+];
+
+const settings_items = [
   {
-    title: "Settings",
-    url: "/settings",
+    title: "General",
+    url: "/settings?section=general",
     icon: Settings,
+  },
+  {
+    title: "Sync Tasks",
+    url: "/settings?section=sync",
+    icon: Layers,
+  },
+  {
+    title: "AI Recommendations",
+    url: "/settings?section=ai",
+    icon: TrendingUp,
+  },
+  {
+    title: "Backup & Import",
+    url: "/settings?section=backup",
+    icon: BookOpen,
   },
 ];
 
@@ -142,13 +168,41 @@ export const SideBar: React.FC<Props> = ({
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 ))}
+
+                <Collapsible defaultOpen className="group/collapsible">
+                  <SidebarMenuItem>
+                    <CollapsibleTrigger asChild>
+                      <SidebarMenuButton>
+                        <Settings />
+                        <span>Settings</span>
+                      </SidebarMenuButton>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <SidebarMenuSub>
+                        {settings_items.map((item) => (
+                          <SidebarMenuSubItem key={item.title}>
+                            <SidebarMenuSubButton asChild>
+                              <a href={"/servers/" + id + item.url}>
+                                <item.icon className="h-4 w-4" />
+                                <span>{item.title}</span>
+                              </a>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    </CollapsibleContent>
+                  </SidebarMenuItem>
+                </Collapsible>
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
         )}
       </SidebarContent>
       <SidebarFooter>
-        <UserMenu me={fullUser || undefined} serverUrl={servers.find(s => s.id === parseInt(id))?.url} />
+        <UserMenu
+          me={fullUser || undefined}
+          serverUrl={servers.find((s) => s.id === parseInt(id))?.url}
+        />
       </SidebarFooter>
     </Sidebar>
   );

--- a/app/components/ui/collapsible.tsx
+++ b/app/components/ui/collapsible.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+import { cn } from "@/lib/utils";
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.Trigger;
+
+const CollapsibleContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn(className)}
+    {...props}
+  />
+));
+CollapsibleContent.displayName = "CollapsibleContent";
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary by Sourcery

Split the server settings interface into query-driven sections and update sidebar navigation accordingly

Enhancements:
- Restructure Settings page into separate “general”, “sync”, “ai”, and “backup” sections based on URL query parameter
- Convert Settings entry in the sidebar into a collapsible group with submenu items linking to each settings section
- Add a reusable Collapsible component for sidebar submenu toggling
- Update DatabaseBackupRestore component title and button texts for clarity
- Standardize form layouts in JellystatsImport and PlaybackReportingImport for consistent alignment