### PR TITLE
Fix issue #99: Watch Time Per Hour wrong timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ This project now uses a Vector-enabled Postgres version (`pgvector/pgvector:pg16
 2. Copy the `docker-compose.yml` file to your desired location. Use tag `:edge` (read more below in [Version Tags](#version-tags).
 3. Change any ports if needed. Default web port is `3000`.
 4. Change the `SECRET_KEY_BASE` in the `docker-compose.yml` file to a random string. You can generate one with `openssl rand -hex 64`.
-5. Start the application with `docker-compose up -d`
-6. Open your browser and navigate to `http://localhost:3000`
-7. Follow the setup wizard to connect your Jellyfin server.
+5. You can configure the timezone in the `docker-compose.yml` file by setting both `TZ` and `NEXT_PUBLIC_TIMEZONE` environment variables for the app service. This ensures correct time display in all charts and statistics.
+6. Start the application with `docker-compose up -d`
+7. Open your browser and navigate to `http://localhost:3000`
+8. Follow the setup wizard to connect your Jellyfin server.
 
 First time load can take a while, depending on the size of your library.
 
@@ -64,4 +65,5 @@ The `:edge` tag always points to the latest commit on the main branch. It contai
 - Backend: Phoenix (Elixir)
 - Database: PostgreSQL
 - Containerization: Docker
+
 

--- a/app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/chart";
 import { formatDuration } from "@/lib/utils";
 import { Statistics } from "@/lib/db";
-import { utcHourToLocalHour } from "@/lib/timezone";
+import { utcHourToLocalHour, TIMEZONE } from "@/lib/timezone";
 
 const chartConfig = {
   minutes: {
@@ -34,8 +34,6 @@ interface Props {
   subtitle: string;
   data: Statistics["watchtime_per_hour"];
 }
-
-const TIMEZONE = process.env.TZ || "Europe/London";
 
 export const WatchTimePerHour: React.FC<Props> = ({
   title,

--- a/app/lib/timezone.ts
+++ b/app/lib/timezone.ts
@@ -1,8 +1,9 @@
 import { format, fromUnixTime } from "date-fns";
 import { fromZonedTime, toZonedTime, getTimezoneOffset } from "date-fns-tz";
 
-// Get the timezone from environment or default to 'Europe/Stockholm'
-export const TIMEZONE = process.env.TZ || "Europe/Stockholm";
+// Get the timezone from environment or default to a sensible fallback
+// Using server-specified timezone if available, otherwise defaulting to UTC
+export const TIMEZONE = process.env.NEXT_PUBLIC_TIMEZONE || process.env.TZ || "Etc/UTC";
 
 /**
  * Converts a UTC hour to the local hour in the configured timezone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       API_URL: "http://phoenix:4000/api"
       TZ: "Europe/Stockholm"
+      NEXT_PUBLIC_TIMEZONE: "Europe/Stockholm"
 
   phoenix:
     image: fredrikburmester/streamystats-phoenix:edge


### PR DESCRIPTION
This PR fixes issue #99 where the Watch Time Per Hour chart on the dashboard was displaying data with the wrong timezone, despite other components showing the correct time.

## Changes:

1. Updated the timezone handling in `app/lib/timezone.ts` to:
   - Use a consistent fallback strategy (using `NEXT_PUBLIC_TIMEZONE` first, then `TZ`, then `Etc/UTC`)
   - Default to UTC instead of Europe/Stockholm when no timezone is specified

2. Modified `WatchTimePerHour.tsx` to:
   - Remove the redundant local timezone definition
   - Import the `TIMEZONE` constant from the timezone utility file

3. Updated `docker-compose.yml` to:
   - Add the `NEXT_PUBLIC_TIMEZONE` environment variable, ensuring client-side code has access to the server timezone setting

4. Added documentation in `README.md` about timezone configuration for self-hosting users

## How to test:
1. Deploy with the timezone set in both `TZ` and `NEXT_PUBLIC_TIMEZONE` environment variables
2. Check that the Watch Time Per Hour chart shows hours in the correct timezone (matching the History and Activity Log)

Fixes #99