### PR TITLE
feat: enhance active sessions with detailed bitrate and transcoding info

### DIFF
--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -211,6 +211,14 @@ export type ActiveSession = {
     hardware_acceleration_type: string;
     transcode_reasons: string[];
   };
+  media_info?: {
+    video_bitrate: number | null;
+    audio_bitrate: number | null;
+    total_bitrate: number | null;
+    video_codec: string | null;
+    audio_codec: string | null;
+    transcode_type: string | null;
+  };
   ip_address?: string;
 };
 


### PR DESCRIPTION
## What

- Extracts and displays video/audio/total bitrate from Jellyfin MediaStreams
- Shows what is being transcoded (audio, video, both) when TranscodingInfo is missing
- Adds a new media_info field to ActiveSession type
- Improves UI to show bitrate and transcoding details in tooltips

## Why

This provides more accurate and helpful information about active sessions, especially for cases where only audio or video is being transcoded, or when Jellyfin omits bitrate info from TranscodingInfo. Users can now see at a glance what is being streamed and at what bitrate, improving transparency and troubleshooting.

---
Closes #100

## Summary by Sourcery

Enhance ActiveSession responses by extracting detailed bitrate and codec information from Jellyfin MediaStreams and adding a media_info field that includes bitrates, codecs, and inferred transcoding type when standard TranscodingInfo is unavailable.

New Features:
- Extract video, audio, and total bitrate from Jellyfin MediaStreams
- Add media_info field to ActiveSession with bitrates, codecs, and transcode type
- Infer transcoding type (audio, video, both, or unknown) when TranscodingInfo is missing