### PR TITLE
feat: watchtime per week day

### DIFF
--- a/app/app/(app)/servers/[id]/(auth)/users/[name]/WatchTimePerDay.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/users/[name]/WatchTimePerDay.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { TrendingUp } from "lucide-react";
 import {
   Bar,
   BarChart,
   CartesianGrid,
-  XAxis,
   ResponsiveContainer,
+  XAxis,
 } from "recharts";
 
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -23,9 +21,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { User } from "@/lib/db";
-import { useMemo } from "react";
 import { formatDuration } from "@/lib/utils";
+import { useMemo } from "react";
 
 const dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 

--- a/app/app/(app)/servers/[id]/(auth)/users/[name]/page.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/users/[name]/page.tsx
@@ -25,7 +25,7 @@ export default async function User({
   }
 
   const user = await getUser(name, server.id, page);
-
+  console.log(user);
   if (!user) {
     redirect("/");
   }
@@ -56,7 +56,7 @@ export default async function User({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
         <GenreStatsGraph data={user.genre_stats} />
-        <WatchTimePerDay data={user.watch_time_per_day} />
+        <WatchTimePerDay data={user.watch_time_per_weekday} />
       </div>
       <HistoryTable
         server={server}

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -172,6 +172,7 @@ export type User = {
   jellyfin_id: string | null;
   watch_stats: { total_watch_time: number; total_plays: number };
   watch_time_per_day: { date: string; total_duration: number }[];
+  watch_time_per_weekday: { day_of_week: number; total_duration: number }[];
   is_administrator: boolean;
   genre_stats: GenreStat[];
   longest_streak: number; // days

--- a/server/lib/streamystat_server_web/controllers/user_controller.ex
+++ b/server/lib/streamystat_server_web/controllers/user_controller.ex
@@ -26,6 +26,7 @@ defmodule StreamystatServerWeb.UserController do
       user ->
         watch_stats = Users.get_user_watch_stats(server_id, user.jellyfin_id)
         watch_time_per_day = Users.get_user_watch_time_per_day(server_id, user.jellyfin_id)
+        watch_time_per_weekday = Users.get_user_watch_time_per_weekday(server_id, user.jellyfin_id)
         genre_stats = Users.get_user_genre_watch_time(server_id, user.jellyfin_id)
         longest_streak = Users.get_user_longest_streak(user.jellyfin_id)
         watch_history = Users.get_user_watch_history(server_id, user.jellyfin_id, params)
@@ -34,6 +35,7 @@ defmodule StreamystatServerWeb.UserController do
           user: user,
           watch_stats: watch_stats,
           watch_time_per_day: watch_time_per_day,
+          watch_time_per_weekday: watch_time_per_weekday,
           genre_stats: genre_stats,
           longest_streak: longest_streak,
           watch_history: watch_history

--- a/server/lib/streamystat_server_web/controllers/user_json.ex
+++ b/server/lib/streamystat_server_web/controllers/user_json.ex
@@ -48,6 +48,7 @@ defmodule StreamystatServerWeb.UserJSON do
     |> Map.put(:watch_stats, watch_stats(params))
     |> Map.put(:watch_history, params[:watch_history] || [])
     |> Map.put(:watch_time_per_day, params[:watch_time_per_day] || [])
+    |> Map.put(:watch_time_per_weekday, params[:watch_time_per_weekday] || [])
     |> Map.put(:genre_stats, params[:genre_stats] || [])
     |> Map.put(:longest_streak, params[:longest_streak] || 0)
   end


### PR DESCRIPTION
## Summary by Sourcery

Add full-stack support for displaying a user’s watch time broken down by weekday, including a new backend query, API enhancements, updated response schemas, and a revamped frontend chart component.

New Features:
- Add backend function to retrieve user watch time aggregated by weekday for the past 30 days
- Introduce frontend chart to display user's watch time per day of the week

Enhancements:
- Ensure all seven weekdays are displayed and convert durations to minutes in the chart
- Update chart labels, tooltip formatting, and component description for weekday view
- Extend user JSON API and TypeScript types to include `watch_time_per_weekday`