### PR TITLE
feat: preferred server 

### DIFF
--- a/app/app/(app)/page.tsx
+++ b/app/app/(app)/page.tsx
@@ -1,12 +1,26 @@
 import { getServers } from "@/lib/db";
+import { getPreferredServer } from "@/lib/preferred-server";
 import { redirect } from "next/navigation";
 
 export default async function Home() {
   const servers = await getServers();
+  const preferredServerId = await getPreferredServer();
 
-  if (servers?.[0]?.id) {
-    redirect(`/servers/${servers[0].id}/dashboard`);
-  } else {
+  // If no servers exist, redirect to setup
+  if (servers.length === 0) {
     redirect("/setup");
   }
+
+  // If we have a preferred server and it exists in the available servers, use it
+  if (preferredServerId) {
+    const preferredServer = servers.find(
+      (server) => server.id === preferredServerId
+    );
+    if (preferredServer) {
+      redirect(`/servers/${preferredServer.id}/dashboard`);
+    }
+  }
+
+  // Fallback to the first available server
+  redirect(`/servers/${servers[0].id}/dashboard`);
 }

--- a/app/app/(app)/servers/[id]/(auth)/layout.tsx
+++ b/app/app/(app)/servers/[id]/(auth)/layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sidebar";
 import { getServer, getServers } from "@/lib/db";
 import { getMe, isUserAdmin } from "@/lib/me";
+import { getPreferredServer } from "@/lib/preferred-server";
 import { redirect } from "next/navigation";
 import { PropsWithChildren, Suspense } from "react";
 
@@ -26,6 +27,7 @@ export default async function layout({ children, params }: Props) {
 
   const servers = await getServers();
   const server = await getServer(id);
+  const preferredServerId = await getPreferredServer();
 
   const me = await getMe();
   const isAdmin = await isUserAdmin();
@@ -36,7 +38,12 @@ export default async function layout({ children, params }: Props) {
 
   return (
     <SidebarProvider>
-      <SideBar servers={servers} me={me} allowedToCreateServer={isAdmin} />
+      <SideBar
+        servers={servers}
+        me={me}
+        allowedToCreateServer={isAdmin}
+        preferredServerId={preferredServerId}
+      />
       <Suspense fallback={<SuspenseLoading />}>
         <ErrorBoundary>
           <main>

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -105,12 +105,14 @@ interface Props {
   servers: Server[];
   me?: UserMe;
   allowedToCreateServer?: boolean;
+  preferredServerId?: number | null;
 }
 
 export const SideBar: React.FC<Props> = ({
   servers,
   me,
   allowedToCreateServer = false,
+  preferredServerId,
 }) => {
   const params = useParams();
   const [fullUser, setFullUser] = useState<User | null>(null);
@@ -150,6 +152,7 @@ export const SideBar: React.FC<Props> = ({
           <ServerSelector
             servers={servers}
             allowedToCreateServer={allowedToCreateServer}
+            preferredServerId={preferredServerId}
           />
         </SidebarGroup>
         <SidebarGroup>

--- a/app/lib/actions/server-actions.ts
+++ b/app/lib/actions/server-actions.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { setPreferredServer as setPreferredServerCookie } from "@/lib/preferred-server";
+
+export const setPreferredServerAction = async (
+  serverId: number
+): Promise<void> => {
+  await setPreferredServerCookie(serverId);
+};

--- a/app/lib/preferred-server.ts
+++ b/app/lib/preferred-server.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+const PREFERRED_SERVER_COOKIE = "streamystats-preferred-server";
+const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year
+
+export const setPreferredServer = async (serverId: number): Promise<void> => {
+  const c = cookies();
+  c.set(PREFERRED_SERVER_COOKIE, serverId.toString(), {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: COOKIE_MAX_AGE,
+    secure: process.env.NODE_ENV === "production",
+  });
+};
+
+export const getPreferredServer = async (): Promise<number | null> => {
+  const c = cookies();
+  const preferredServerCookie = c.get(PREFERRED_SERVER_COOKIE);
+
+  if (preferredServerCookie?.value) {
+    const serverId = parseInt(preferredServerCookie.value, 10);
+    return isNaN(serverId) ? null : serverId;
+  }
+
+  return null;
+};
+
+export const clearPreferredServer = async (): Promise<void> => {
+  const c = cookies();
+  c.delete(PREFERRED_SERVER_COOKIE);
+};


### PR DESCRIPTION
Using cookie to save favorite server. On / redirects to that server.

## Summary by Sourcery

Enable users to star a server as their preferred choice, persist that preference in a cookie, and automatically redirect to that server’s dashboard on visit.

New Features:
- Allow users to mark a server as preferred via a star icon in the server selector UI
- Persist the preferred server in a cookie and redirect the homepage to its dashboard

Enhancements:
- Add lib functions to set, get, and clear the preferred-server cookie
- Propagate preferredServerId prop through layout, sidebar, and selector components
- Update redirect logic to use the preferred server fallback before defaulting to the first server