### PR TITLE
feat(job-server): allow setting of listening host

### DIFF
--- a/apps/job-server/src/index.ts
+++ b/apps/job-server/src/index.ts
@@ -15,6 +15,10 @@ const app = express();
 const PORT = parseInt(process.env.PORT || "3000", 10);
 const HOST = process.env.HOST || "localhost";
 
+if (isNaN(PORT) || PORT < 1 || PORT > 65535) {
+  throw new Error(`Invalid PORT value: "${process.env.PORT}". Please provide a valid port number between 1 and 65535.`);
+}
+
 // Middleware
 app.use(helmet());
 app.use(cors());

--- a/apps/job-server/src/index.ts
+++ b/apps/job-server/src/index.ts
@@ -12,7 +12,8 @@ import jobRoutes from "./routes/jobs";
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = parseInt(process.env.PORT || "3000", 10);
+const HOST = process.env.HOST || "localhost";
 
 // Middleware
 app.use(helmet());
@@ -88,10 +89,10 @@ async function startServer() {
     await sessionPoller.start();
 
     // Start the server
-    app.listen(PORT, () => {
+    app.listen(PORT, HOST, () => {
       console.log(`🚀 Job server running on port ${PORT}`);
-      console.log(`📊 Health check: http://localhost:${PORT}/health`);
-      console.log(`🔧 API docs: http://localhost:${PORT}/`);
+      console.log(`📊 Health check: http://${HOST}:${PORT}/health`);
+      console.log(`🔧 API docs: http://${HOST}:${PORT}/`);
 
       const status = activityScheduler.getStatus();
       console.log(


### PR DESCRIPTION
To make running streamyfin without docker a bit easier and safer (unlike the console message the job-server binds to `*` by default!

You can also pass the HOST env variable via docker compose too in case someone is interested in that.

I'm not 100% sure defaulting to `localhost` is correct, it would certainly match what is logged on the cli. But to keep the same behavior it should default to `0.0.0.0`. 

I can change this if required.

ref: #137

## Summary by Sourcery

Allow configuring the job-server listening host via HOST environment variable, defaulting to 'localhost', update server startup logs to use the configured host and port, and parse PORT env variable as an integer.

New Features:
- Allow setting the job-server's listening host via HOST environment variable.

Enhancements:
- Parse PORT environment variable as an integer to ensure numeric port values.
- Update health check and API docs console messages to include the configured host.