### PR TITLE
feat: use ScrollArea for recomendations

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarSeriesStatistics.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarSeriesStatistics.tsx
@@ -20,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   hideSeriesRecommendation,
   SeriesRecommendationItem,
@@ -124,7 +125,7 @@ export const SimilarSeriesStatistics = ({ data, server }: Props) => {
             </p>
           </div>
         ) : (
-          <div className="overflow-x-auto pt-4">
+          <ScrollArea className="py-4">
             <div className="flex gap-4 min-w-full w-max">
               {recommendations.map((recommendation) => {
                 const item = recommendation.item;
@@ -290,7 +291,8 @@ export const SimilarSeriesStatistics = ({ data, server }: Props) => {
                 );
               })}
             </div>
-          </div>
+            <ScrollBar orientation="horizontal" />
+          </ScrollArea>
         )}
       </CardContent>
     </Card>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarStatistics.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarStatistics.tsx
@@ -37,7 +37,7 @@ interface Props {
   server: Server;
 }
 
-export const SimilarStatstics = ({ data, server }: Props) => {
+export const SimilarStatistics = ({ data, server }: Props) => {
   const [recommendations, setRecommendations] = useState(data);
   const [hidingItems, setHidingItems] = useState<Set<string>>(new Set());
 

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarStatstics.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/SimilarStatstics.tsx
@@ -20,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import {
   hideRecommendation,
@@ -166,7 +167,7 @@ export const SimilarStatstics = ({ data, server }: Props) => {
           {types.map((type) => (
             <TabsContent key={type} value={type.toLowerCase()} className="">
               {/* Horizontal scrollable container */}
-              <div className="overflow-x-auto pt-4">
+              <ScrollArea className="py-4">
                 <div className="flex gap-4 min-w-full w-max">
                   {groupedItems[type].map((recommendation) => {
                     const item = recommendation.item;
@@ -344,7 +345,8 @@ export const SimilarStatstics = ({ data, server }: Props) => {
                     );
                   })}
                 </div>
-              </div>
+                <ScrollBar orientation="horizontal" />
+              </ScrollArea>
             </TabsContent>
           ))}
         </Tabs>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/page.tsx
@@ -12,7 +12,7 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { ActiveSessions } from "./ActiveSessions";
 import { MostWatchedItems } from "./MostWatchedItems";
-import { SimilarStatstics } from "./SimilarStatstics";
+import { SimilarStatistics } from "./SimilarStatistics";
 import { SimilarSeriesStatistics } from "./SimilarSeriesStatistics";
 import { UserActivityWrapper } from "./UserActivityWrapper";
 import { UserLeaderboard } from "./UserLeaderboard";
@@ -77,7 +77,7 @@ async function GeneralStats({
   return (
     <div className="flex flex-col gap-6">
       {/* <ServerSetupMonitor serverId={server.id} serverName={server.name} /> */}
-      <SimilarStatstics data={similarData} server={server} />
+      <SimilarStatistics data={similarData} server={server} />
       <SimilarSeriesStatistics data={similarSeriesData} server={server} />
       <MostWatchedItems data={data} server={server} />
       {sas ? (


### PR DESCRIPTION
feat: use ScrollArea for recomendations
---
A simple change that really improves the look of the recommendations.
Notably, the `ui/scroll-area` components were already part of the project, so no new dependencies were introduced.

> Auto summary:

This update enhances the UI of the similar statistics cards section on the dashboard by enabling horizontal scrolling. It ensures that all recommendation cards remain accessible, even when they exceed the width of their container.

### ✨ Changes

* Replaced the `overflow-x-auto` wrapper with the `<ScrollArea>` component.
* Added a `<ScrollBar orientation="horizontal" />` for better UX and visual feedback.
* Imported `ScrollArea` and `ScrollBar` from `@/components/ui/scroll-area`.

### 📸 Before & After

* **Before**:
![image](https://github.com/user-attachments/assets/7919fe6e-c355-499b-9f1b-f446d1b5de5e)

* **After**: 
![image](https://github.com/user-attachments/assets/a1e7cf9c-18f8-4787-bc65-d21787ef4dd8)

---

## Summary by Sourcery

Enable horizontal scrolling for recommendation cards by replacing overflow wrappers with the ScrollArea component and adding a horizontal ScrollBar, and correct the SimilarStatstics component name typo.

New Features:
- Enable horizontal scrolling for recommendation cards in both SimilarStatistics and SimilarSeriesStatistics using the ScrollArea and ScrollBar components.

Bug Fixes:
- Fix typo in component name from SimilarStatstics to SimilarStatistics.

Enhancements:
- Replace plain overflow-x-auto wrappers with the custom ScrollArea component for a consistent UI experience.