### PR TITLE
fix(nextjs-app): correctly set body size limit

### DIFF
--- a/apps/nextjs-app/next.config.mjs
+++ b/apps/nextjs-app/next.config.mjs
@@ -15,9 +15,9 @@ const nextConfig = {
   },
   experimental: {
     nodeMiddleware: true,
-  },
-  serverActions: {
-    bodySizeLimit: "500mb",
+    serverActions: {
+      bodySizeLimit: "500mb",
+    },
   },
 };
 


### PR DESCRIPTION
closes #146 

Per https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions, it is supposed to be defined in `experimental.serverActions.bodySizeLimit`

## Summary by Sourcery

Bug Fixes:
- Move bodySizeLimit into experimental.serverActions per Next.js docs