### PR TITLE
feat: filter out non-media types in genre stats

### DIFF
--- a/apps/nextjs-app/lib/db/users.ts
+++ b/apps/nextjs-app/lib/db/users.ts
@@ -476,7 +476,11 @@ export const getUserGenreStats = async (
     .from(sessions)
     .innerJoin(items, eq(sessions.itemId, items.id))
     .where(
-      and(eq(sessions.userId, userId), eq(sessions.serverId, Number(serverId)))
+      and(
+        eq(sessions.userId, userId),
+        eq(sessions.serverId, Number(serverId)),
+        inArray(items.type, ["Movie", "Episode", "Series"])
+      )
     );
 
   const genreMap: Record<string, { watchTime: number; playCount: number }> = {};


### PR DESCRIPTION
This commit filters out non-media types _(e.g., songs, home-videos, playlists, collections, folders)_ when calculating genre statistics. This ensures that only Movies, Episodes, and Series are included in the calculations, providing more accurate and relevant genre stats for users.

Screenshots just for reference:
Before:
<img width="1002" height="773" alt="image" src="https://github.com/user-attachments/assets/f018a5f1-05cf-4b83-aad2-47cdd478f1fe" />

After:
<img width="1001" height="774" alt="image" src="https://github.com/user-attachments/assets/da3b2fcb-f775-40d9-ab6f-06bb36ebf3e2" />

## Summary by Sourcery

Enhancements:
- Filter out non-media item types when calculating user genre statistics to include only movies, episodes, and series