### PR TITLE
feat: set host in compose files for job-server

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,7 @@ services:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@vectorchord:5432/${POSTGRES_DB:-streamystats}
       - PORT=3005
+      - HOST=0.0.0.0
     depends_on:
       vectorchord:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@vectorchord:5432/${POSTGRES_DB:-streamystats}
       - PORT=3005
+      - HOST=0.0.0.0
     depends_on:
       vectorchord:
         condition: service_healthy


### PR DESCRIPTION
This change sets the host to 0.0.0.0 in both the development and production docker-compose files.

Closes #171

## Summary by Sourcery

Set the host binding for the job-server to 0.0.0.0 in both development and production Docker Compose configurations

New Features:
- Add HOST=0.0.0.0 environment variable to the job-server service in docker-compose.dev.yml
- Add HOST=0.0.0.0 environment variable to the job-server service in docker-compose.yml