### PR TITLE
chore: use same fallback for when JOB_SERVER_URL is not set

### DIFF
--- a/apps/job-server/dist/jobs/embedding-jobs.js
+++ b/apps/job-server/dist/jobs/embedding-jobs.js
@@ -316,7 +316,7 @@ async function generateItemEmbeddingsJob(job) {
                         const jobServerUrl = process.env.JOB_SERVER_URL &&
                             process.env.JOB_SERVER_URL !== "undefined"
                             ? process.env.JOB_SERVER_URL
-                            : "http://localhost:3001";
+                            : "http://localhost:3005";
                         const response = await fetch(`${jobServerUrl}/api/jobs/start-embedding`, {
                             method: "POST",
                             headers: {

--- a/apps/job-server/dist/test-job-status-map.js
+++ b/apps/job-server/dist/test-job-status-map.js
@@ -45,7 +45,7 @@ async function testJobStatusInServerStatus() {
         console.log("📦 Initializing job queue...");
         await (0, queue_1.getJobQueue)();
         // Test the endpoint by making a direct HTTP request
-        const baseUrl = process.env.JOB_SERVER_URL || "http://localhost:3001";
+        const baseUrl = process.env.JOB_SERVER_URL || "http://localhost:3005";
         const url = `${baseUrl}/api/jobs/server-status`;
         console.log(`🌐 Testing endpoint: ${url}`);
         try {

--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -443,7 +443,7 @@ export async function generateItemEmbeddingsJob(job: any) {
               process.env.JOB_SERVER_URL &&
               process.env.JOB_SERVER_URL !== "undefined"
                 ? process.env.JOB_SERVER_URL
-                : "http://localhost:3001";
+                : "http://localhost:3005";
 
             const response = await fetch(
               `${jobServerUrl}/api/jobs/start-embedding`,

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
@@ -178,7 +178,7 @@ export function EmbeddingsManager({ server }: { server: Server }) {
       const jobServerUrl =
         process.env.JOB_SERVER_URL && process.env.JOB_SERVER_URL !== "undefined"
           ? process.env.JOB_SERVER_URL
-          : "http://localhost:3001";
+          : "http://localhost:3005";
 
       const response = await fetch(`${jobServerUrl}/api/jobs/cleanup-stale`, {
         method: "POST",

--- a/apps/nextjs-app/app/api/jobs/servers/[serverId]/sync-status/route.ts
+++ b/apps/nextjs-app/app/api/jobs/servers/[serverId]/sync-status/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     const jobServerUrl =
       process.env.JOB_SERVER_URL && process.env.JOB_SERVER_URL !== "undefined"
         ? process.env.JOB_SERVER_URL
-        : "http://localhost:3000";
+        : "http://localhost:3005";
     const response = await fetch(
       `${jobServerUrl}/api/jobs/servers/${serverId}/sync-status`,
       {

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -353,7 +353,7 @@ export const startEmbedding = async (serverId: number) => {
     const jobServerUrl =
       process.env.JOB_SERVER_URL && process.env.JOB_SERVER_URL !== "undefined"
         ? process.env.JOB_SERVER_URL
-        : "http://localhost:3001";
+        : "http://localhost:3005";
 
     // Queue the embedding job (this will be implemented in the job server)
     const response = await fetch(`${jobServerUrl}/api/jobs/start-embedding`, {
@@ -392,7 +392,7 @@ export const stopEmbedding = async (serverId: number) => {
     const jobServerUrl =
       process.env.JOB_SERVER_URL && process.env.JOB_SERVER_URL !== "undefined"
         ? process.env.JOB_SERVER_URL
-        : "http://localhost:3001";
+        : "http://localhost:3005";
 
     // Stop the embedding job (this will be implemented in the job server)
     const response = await fetch(`${jobServerUrl}/api/jobs/stop-embedding`, {

--- a/apps/nextjs-app/lib/server.ts
+++ b/apps/nextjs-app/lib/server.ts
@@ -85,7 +85,7 @@ export async function getServerSyncStatus(serverId: number) {
   const jobServerUrl =
     process.env.JOB_SERVER_URL && process.env.JOB_SERVER_URL !== "undefined"
       ? process.env.JOB_SERVER_URL
-      : "http://localhost:3000";
+      : "http://localhost:3005";
 
   try {
     const response = await fetch(


### PR DESCRIPTION
While working on #137 I noticed that the defaulting for when process.env.JOB_SERVER_URL is undefined is all over the placed. I filed #148 to track this required cleanup. The [compose](https://github.com/fredrikburmester/streamystats/blob/e4e782206714e9c491bd1472370daa40e59a6073/docker-compose.yml#L55) file sets the PORT to 3005, which was also used as a default in a lot of placed. I made them all consistent.

This fixes #148

## Summary by Sourcery

Enhancements:
- Unify the JOB_SERVER_URL default to http://localhost:3005 in the job server, Next.js application, API routes, EmbeddingsManager component, database modules, and related tests