### PR TITLE
fix(next-app): /setup is admin only unless there are no servers yet

### DIFF
--- a/apps/nextjs-app/middleware.ts
+++ b/apps/nextjs-app/middleware.ts
@@ -66,8 +66,8 @@ export const config = {
   ],
 };
 
-const ADMIN_ONLY_PATHS = ["history", "settings", "activities", "users"];
-const PUBLIC_PATHS = ["login", "setup"];
+const ADMIN_ONLY_PATHS = ["history", "settings", "activities", "users", "setup"];
+const PUBLIC_PATHS = ["login"];
 
 /**
  * Parse URL pathname to extract server ID, page, and user name


### PR DESCRIPTION
Fixes #184

This PR moves /setup to ADMIN_ONLY_PATHS, so only an existing admin can add a new server.
The middle already redirects and returns early when servers.length === 0, so you can still do a setup without authenticating during on-boarding.

This fixed turned out to be easier than I expected (or more likely my understanding of how nextjs-apps and the middleware work improved over the last few days)

## Summary by Sourcery

Bug Fixes:
- Restrict the `/setup` route to admins by moving it from public to admin-only paths