### PR TITLE
feat: allow setting OPENAI_BASE_URL and EMBEDDING_MODEL via environment (closes #141)

### DIFF
--- a/apps/job-server/src/jobs/config.ts
+++ b/apps/job-server/src/jobs/config.ts
@@ -1,15 +1,23 @@
 import OpenAI from "openai";
 
 // Initialize OpenAI client (optional)
-export const openai = process.env.OPENAI_API_KEY
+const {
+  OPENAI_API_KEY,
+  OPENAI_BASE_URL = "https://api.openai.com/v1",
+  EMBEDDING_MODEL = "text-embedding-3-small",
+} = process.env;
+
+export const openai = OPENAI_API_KEY
   ? new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
+      apiKey: OPENAI_API_KEY,
+      baseURL: OPENAI_BASE_URL,
     })
   : null;
 
 // Configuration constants
 export const OPENAI_CONFIG = {
-  EMBEDDING_MODEL: "text-embedding-3-small",
+  BASE_URL: OPENAI_BASE_URL,
+  EMBEDDING_MODEL,
   EMBEDDING_DIMENSIONS: 1536,
   MAX_TEXT_LENGTH: 8000,
   MAX_RETRIES: 3,

--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -146,6 +146,7 @@ export async function generateItemEmbeddingsJob(job: any) {
 
       const openaiClient = new OpenAI({
         apiKey: config.openaiApiKey,
+        baseURL: OPENAI_CONFIG.BASE_URL,
         timeout: TIMEOUT_CONFIG.DEFAULT,
         maxRetries: OPENAI_CONFIG.MAX_RETRIES,
       });


### PR DESCRIPTION
This allows setting `OPENAI_BASE_URL` and `EMBEDDING_MODEL` via environment variables to allow using other OpenAi compatible APIs.

(closes #141)

## Summary by Sourcery

Enable customization of the OpenAI API base URL and embedding model through environment variables and update the configuration and client setup to use these settings.

New Features:
- Allow setting OPENAI_BASE_URL and EMBEDDING_MODEL via environment variables

Enhancements:
- Apply default values for OPENAI_BASE_URL and EMBEDDING_MODEL in configuration
- Pass the configured baseURL and embedding model into OpenAI client instantiations