### PR TITLE
fix: ActiveSession and UserLeaderBoardTable should use user.name not user.id

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/ActiveSessions.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/ActiveSessions.tsx
@@ -191,7 +191,7 @@ export function ActiveSessions({ server }: { server: Server }) {
                       <div className="flex justify-start">
                         {session.user ? (
                           <Link
-                            href={`/servers/${server.id}/users/${session.user.id}`}
+                            href={`/servers/${server.id}/users/${session.user.name}`}
                             className="flex items-center gap-2 group"
                           >
                             <JellyfinAvatar

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/UserLeaderBoardTable.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/UserLeaderBoardTable.tsx
@@ -93,7 +93,7 @@ export const UserLeaderboardTable = ({
                   </TableCell>
                   <TableCell>
                     <Link
-                      href={`/servers/${server.id}/users/${user.id}`}
+                      href={`/servers/${server.id}/users/${user.name}`}
                       className="flex items-center gap-2 group"
                     >
                       <JellyfinAvatar

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/ai/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/ai/page.tsx
@@ -10,6 +10,7 @@ export default async function AISettings(props: {
 }) {
   const { id } = await props.params;
   const server = await getServer({ serverId: id });
+
   if (!server) {
     redirect("/setup");
   }


### PR DESCRIPTION
Some cherry-picking from #177

## Summary by Sourcery

Bug Fixes:
- Use user.name instead of user.id for user link URLs in ActiveSessions and UserLeaderboardTable