### PR TITLE
feat: switch to next/link in SideBar and ServerSelector

### DIFF
--- a/apps/nextjs-app/components/ServerSelector.tsx
+++ b/apps/nextjs-app/components/ServerSelector.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { SidebarMenuButton } from "./ui/sidebar";
+import Link from "next/link";
 
 interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   servers: Server[];
@@ -76,10 +77,10 @@ export const ServerSelector: React.FC<Props> = ({
         ))}
         {allowedToCreateServer && (
           <DropdownMenuItem>
-            <a href={"/setup/"} className="flex flex-row items-center gap-2">
+            <Link href="/setup" className="flex flex-row items-center gap-2">
               <PlusIcon />
               <span>Add server</span>
-            </a>
+            </Link>
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/apps/nextjs-app/components/SideBar.tsx
+++ b/apps/nextjs-app/components/SideBar.tsx
@@ -39,6 +39,7 @@ import {
   SidebarMenuSubItem,
 } from "./ui/sidebar";
 import { ShowAdminStatisticsSwitch } from "./ShowAdminStatisticsSwitch";
+import Link from "next/link";
 
 const dashboard_items = [
   {
@@ -162,10 +163,10 @@ export const SideBar: React.FC<Props> = ({
                       {dashboard_items.map((item) => (
                         <SidebarMenuSubItem key={item.title}>
                           <SidebarMenuSubButton asChild>
-                            <a href={"/servers/" + id + item.url}>
+                            <Link href={`/servers/${id}${item.url}`}>
                               <item.icon className="h-4 w-4" />
                               <span>{item.title}</span>
-                            </a>
+                            </Link>
                           </SidebarMenuSubButton>
                         </SidebarMenuSubItem>
                       ))}
@@ -176,10 +177,10 @@ export const SideBar: React.FC<Props> = ({
               {items.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <a href={"/servers/" + id + item.url}>
+                    <Link href={`/servers/${id}${item.url}`}>
                       <item.icon />
                       <span>{item.title}</span>
-                    </a>
+                    </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -194,10 +195,10 @@ export const SideBar: React.FC<Props> = ({
                 {admin_items.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
-                      <a href={"/servers/" + id + item.url}>
+                      <Link href={`/servers/${id}${item.url}`}>
                         <item.icon />
                         <span>{item.title}</span>
-                      </a>
+                      </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 ))}
@@ -215,10 +216,10 @@ export const SideBar: React.FC<Props> = ({
                         {settings_items.map((item) => (
                           <SidebarMenuSubItem key={item.title}>
                             <SidebarMenuSubButton asChild>
-                              <a href={"/servers/" + id + item.url}>
+                              <Link href={`/servers/${id}${item.url}`}>
                                 <item.icon className="h-4 w-4" />
                                 <span>{item.title}</span>
-                              </a>
+                              </Link>
                             </SidebarMenuSubButton>
                           </SidebarMenuSubItem>
                         ))}


### PR DESCRIPTION
Another cherry-pick from #177 this makes the ServerSelector and SideBar respect the basePath in next.config.mjs.