### PR TITLE
fix: change all snake_case to camelCase

### DIFF
--- a/apps/job-server/dist/jellyfin/sync/activities.js
+++ b/apps/job-server/dist/jellyfin/sync/activities.js
@@ -10,6 +10,7 @@ const database_1 = require("@streamystats/database");
 const client_1 = require("../client");
 const sync_metrics_1 = require("../sync-metrics");
 const p_map_1 = __importDefault(require("p-map"));
+const ACTIVITYLOG_SYSTEM_USERID = '00000000000000000000000000000000';
 async function syncActivities(server, options = {}) {
     const { pageSize = 100, maxPages = 1000, // Prevent infinite loops
     concurrency = 5, apiRequestDelayMs = 100, } = options;
@@ -231,6 +232,9 @@ async function processActivity(jellyfinActivity, serverId, metrics) {
                 .limit(1);
             if (userExists.length > 0) {
                 validUserId = jellyfinActivity.UserId;
+            }
+            else if (jellyfinActivity.UserId == ACTIVITYLOG_SYSTEM_USERID) {
+                // this is a system event (plugin install/uninstall, ...) we do not print a warning
             }
             else {
                 console.warn(`Activity ${jellyfinActivity.Id} references non-existent user ${jellyfinActivity.UserId}, setting to null`);

--- a/apps/job-server/dist/jellyfin/workers.js
+++ b/apps/job-server/dist/jellyfin/workers.js
@@ -44,10 +44,10 @@ async function jellyfinSyncWorker(job) {
             case "activities":
                 result = await (0, sync_1.syncActivities)(server, options.activityOptions);
                 break;
-            case "recent_items":
+            case "recentItems":
                 result = await (0, sync_1.syncRecentlyAddedItems)(server, options.itemOptions?.recentItemsLimit || 100);
                 break;
-            case "recent_activities":
+            case "recentActivities":
                 result = await (0, sync_1.syncRecentActivities)(server, {
                     pageSize: 100,
                     maxPages: 10,
@@ -155,7 +155,7 @@ async function jellyfinRecentItemsSyncWorker(job) {
     return jellyfinSyncWorker({
         data: {
             serverId: job.data.serverId,
-            syncType: "recent_items",
+            syncType: "recentItems",
             options: job.data.options,
         },
     });
@@ -167,7 +167,7 @@ async function jellyfinRecentActivitiesSyncWorker(job) {
     return jellyfinSyncWorker({
         data: {
             serverId: job.data.serverId,
-            syncType: "recent_activities",
+            syncType: "recentActivities",
             options: job.data.options,
         },
     });

--- a/apps/job-server/src/jellyfin/workers.ts
+++ b/apps/job-server/src/jellyfin/workers.ts
@@ -19,8 +19,8 @@ export interface JellyfinSyncJobData {
     | "libraries"
     | "items"
     | "activities"
-    | "recent_items"
-    | "recent_activities";
+    | "recentItems"
+    | "recentActivities";
   options?: SyncOptions;
 }
 
@@ -69,13 +69,13 @@ export async function jellyfinSyncWorker(job: {
       case "activities":
         result = await syncActivities(server, options.activityOptions);
         break;
-      case "recent_items":
+      case "recentItems":
         result = await syncRecentlyAddedItems(
           server,
           options.itemOptions?.recentItemsLimit || 100
         );
         break;
-      case "recent_activities":
+      case "recentActivities":
         result = await syncRecentActivities(server, {
           pageSize: 100,
           maxPages: 10,
@@ -215,7 +215,7 @@ export async function jellyfinRecentItemsSyncWorker(job: {
   return jellyfinSyncWorker({
     data: {
       serverId: job.data.serverId,
-      syncType: "recent_items",
+      syncType: "recentItems",
       options: job.data.options,
     },
   });
@@ -230,7 +230,7 @@ export async function jellyfinRecentActivitiesSyncWorker(job: {
   return jellyfinSyncWorker({
     data: {
       serverId: job.data.serverId,
-      syncType: "recent_activities",
+      syncType: "recentActivities",
       options: job.data.options,
     },
   });

--- a/apps/nextjs-app/components/SideBar.tsx
+++ b/apps/nextjs-app/components/SideBar.tsx
@@ -41,7 +41,7 @@ import {
 import { ShowAdminStatisticsSwitch } from "./ShowAdminStatisticsSwitch";
 import Link from "next/link";
 
-const dashboard_items = [
+const dashboardItems = [
   {
     title: "General",
     url: "/dashboard",
@@ -59,7 +59,7 @@ const dashboard_items = [
   },
 ];
 
-const admin_items = [
+const adminItems = [
   {
     title: "Activity Log",
     url: "/activities",
@@ -77,7 +77,7 @@ const admin_items = [
   },
 ];
 
-const settings_items = [
+const settingsItems = [
   {
     title: "General",
     url: "/settings/general",
@@ -160,7 +160,7 @@ export const SideBar: React.FC<Props> = ({
                   </CollapsibleTrigger>
                   <CollapsibleContent>
                     <SidebarMenuSub>
-                      {dashboard_items.map((item) => (
+                      {dashboardItems.map((item) => (
                         <SidebarMenuSubItem key={item.title}>
                           <SidebarMenuSubButton asChild>
                             <Link href={`/servers/${id}${item.url}`}>
@@ -192,7 +192,7 @@ export const SideBar: React.FC<Props> = ({
             <SidebarGroupLabel>Admin</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {admin_items.map((item) => (
+                {adminItems.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
                       <Link href={`/servers/${id}${item.url}`}>
@@ -213,7 +213,7 @@ export const SideBar: React.FC<Props> = ({
                     </CollapsibleTrigger>
                     <CollapsibleContent>
                       <SidebarMenuSub>
-                        {settings_items.map((item) => (
+                        {settingsItems.map((item) => (
                           <SidebarMenuSubItem key={item.title}>
                             <SidebarMenuSubButton asChild>
                               <Link href={`/servers/${id}${item.url}`}>

--- a/apps/nextjs-app/components/ui/sidebar.tsx
+++ b/apps/nextjs-app/components/ui/sidebar.tsx
@@ -25,7 +25,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_NAME = "sidebarState"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"


### PR DESCRIPTION
## Summary by Sourcery

Convert all snake_case names to camelCase across Jellyfin workers and Next.js sidebar codebase, and introduce a constant to suppress warnings for system activity events

New Features:
- Add ACTIVITYLOG_SYSTEM_USERID constant to skip warnings for system-generated activities during sync

Enhancements:
- Rename syncType, case labels, interface fields, and function calls from snake_case to camelCase in job-server
- Update Next.js sidebar arrays and cookie constant from snake_case to camelCase