### PR TITLE
chore: document dockerless install

### DIFF
--- a/DOCKERLESS.md
+++ b/DOCKERLESS.md
@@ -23,7 +23,7 @@ cd /tmp/pgvector
 make
 make install
 
-# NOTE: optionally cleanup the dev requirements
+# NOTE: optionally clean up the dev requirements
 apt remove build-essential postgresql-server-dev-15 clang-14 icu-devtools lib32gcc-s1 lib32stdc++6 libc6-i386 libclang-common-14-dev libclang-cpp14 libclang-rt-14-dev libclang1-14 libcurl3-nss libffi-dev libgc1 libicu-dev libncurses-dev libncurses6 libobjc-12-dev libobjc4 libpfm4 libpq-dev libtinfo-dev libxml2-dev libyaml-0-2 libz3-dev llvm-14 llvm-14-dev llvm-14-linker-tools llvm-14-runtime llvm-14-tools nss-plugin-pem postgresql-server-dev-15 python3-pygments python3-yaml
 apt autoremove
 ```

--- a/DOCKERLESS.md
+++ b/DOCKERLESS.md
@@ -1,0 +1,219 @@
+# Dockerless Installation
+
+If you want to run streamystats but do not want to use docker, you can with a bit of elbow grease! This guide assumes you have at least basic linux and postgres knowledge.
+This has been tested on **Debian Bookworm**.
+
+## PostgreSQL
+
+Streamystats depends on the vector extension so you might need to use the upstream postgresql repos or compile it yourself.
+
+Installing PostgreSQL:
+```bash
+# NOTE: on Debian Bookwarm the default postgresql version is 15
+apt install postgresql postgresql-client
+systemctl enable --now postgresql@15-main.service
+```
+
+Since there is no pgvector package we need to compile it ourselves:
+```bash
+apt install git build-essential postgresql-server-dev-15
+
+git clone https://github.com/pgvector/pgvector.git /tmp/pgvector
+cd /tmp/pgvector
+make
+make install
+
+# NOTE: optionally cleanup the dev requirements
+apt remove build-essential postgresql-server-dev-15 clang-14 icu-devtools lib32gcc-s1 lib32stdc++6 libc6-i386 libclang-common-14-dev libclang-cpp14 libclang-rt-14-dev libclang1-14 libcurl3-nss libffi-dev libgc1 libicu-dev libncurses-dev libncurses6 libobjc-12-dev libobjc4 libpfm4 libpq-dev libtinfo-dev libxml2-dev libyaml-0-2 libz3-dev llvm-14 llvm-14-dev llvm-14-linker-tools llvm-14-runtime llvm-14-tools nss-plugin-pem postgresql-server-dev-15 python3-pygments python3-yaml
+apt autoremove
+```
+
+### Creating the database
+
+```bash
+export PG_VER=15
+export DB_NAME=jellystats
+export DB_PASS=$(pwgen -s 24 1)
+
+echo "Creating ${DB_NAME} role with password: ${DB_PASS}"
+echo "CREATE USER ${DB_NAME} WITH LOGIN PASSWORD '${DB_PASS}';" | sudo -i -u postgres psql
+echo "CREATE DATABASE ${DB_NAME} OWNER ${DB_NAME};" | sudo -i -u postgres psql
+
+cat >> /etc/postgresql/${PG_VER}/main/pg_hba.conf << EOF
+# ${DB_NAME}
+host    ${DB_NAME}      ${DB_NAME}      127.0.0.1/32    scram-sha-256
+host    ${DB_NAME}      ${DB_NAME}      ::1/128         scram-sha-256
+EOF
+
+export DATABASE_URL=postgresql://${DB_NAME}:${DB_PASS}@localhost:5432/${DB_NAME}
+echo 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";' | psql "$DATABASE_URL"
+echo 'CREATE EXTENSION IF NOT EXISTS "vector";' | sudo -u postgres psql -d ${DB_NAME} # NOTE: need super user
+```
+
+## Streamystats
+
+Everything except the database and systemd unit will be contain within `/opt/streamystats`, we will also use a nodeenv to keep everything seperate from the systems default node.
+
+### Prepareing the nodeenv
+Creating the nodeenv:
+```bash
+[ -d /opt/streamystats/nodeenv ] || nodeenv --prebuilt -n 23.11.1 /opt/streamystats/nodeenv
+source /opt/streamystats/nodeenv/bin/activate
+npm install -g pnpm
+```
+
+### Installing from source
+Cloning the source:
+```bash
+git clone https://github.com/fredrikburmester/streamystats.git /opt/streamystats/src
+```
+
+Installing the database package:
+```bash
+cd /opt/streamystats/src/packages/database
+pnpm install --frozen-lockfile
+pnpm build
+npx drizzle-kit migrate
+pnpm db:status
+```
+
+Installing the job-server package:
+```bash
+cd /opt/streamystats/src/apps/job-server
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+**If you want a different base URI e.g. /streamystats, you need to export NEXT_PUBLIC_BASE_PATH before building the next-app!**
+
+Installing the next-app package:
+```bash
+cd /opt/streamystats/src/apps/nextjs-app
+#export NEXT_PUBLIC_BASE_PATH=/streamstats
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+### Configuration
+
+**You should still have the DB_NAME and DB_PASS variables set from earlier, if not replace them with the correct values!**
+
+This configuration listens on localhost so needs to be placed behind a reverse proxy. Change this as needed for your setup.
+
+```bash
+mkdir -p /opt/streamystats/etc
+cat > /opt/streamystats/etc/db.env << EOF
+DATABASE_URL=postgresql://${DB_NAME}:${DB_PASS}@localhost:5432/${DB_NAME}
+TZ=UTC
+EOF
+
+cat > /opt/streamystats/etc/job-server.env << EOF
+HOST=localhost
+PORT=3005
+EOF
+
+cat > /opt/streamystats/etc/nextjs-app.env << EOF
+HOST=localhost
+PORT=3000
+#NEXT_PUBLIC_BASE_PATH=/streamystats
+JOB_SERVER_URL=http://localhost:3005
+EOF
+```
+
+### Running with systemd
+```bash
+useradd --system --home /opt/streamystats --create-home --shell /usr/sbin/nologin --user-group streamystats
+chown -R streamystats:streamystats /opt/streamystats/{src,etc}
+
+cat > /lib/systemd/system/streamystats-db-migration.service << EOF
+[Unit]
+Description=Streamystats is a statistics service for Jellyfin, providing analytics and data visualization.
+Requires=network-online.target
+#Requires=sssd.service
+
+BindsTo=postgresql@15-main.service
+After=postgresql@15-main.service
+
+[Service]
+EnvironmentFile=/opt/streamystats/etc/db.env
+Environment=PATH=/opt/streamystats/nodeenv/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
+Type=oneshot
+WorkingDirectory=/opt/streamystats/src/packages/database
+ExecStart=/opt/streamystats/nodeenv/bin/npx drizzle-kit migrate
+User=streamystats
+Group=streamystats
+PrivateTmp=true
+SyslogIdentifier=streamystats-db-migration
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /lib/systemd/system/streamystats-job-server.service << EOF
+[Unit]
+Description=Streamystats is a statistics service for Jellyfin, providing analytics and data visualization.
+Requires=network-online.target
+#Requires=sssd.service
+Requires=jellyfin.service
+After=streamystats-db-migration.service
+
+BindsTo=postgresql@15-main.service
+After=postgresql@15-main.service
+
+[Service]
+EnvironmentFile=/opt/streamystats/etc/db.env
+EnvironmentFile=/opt/streamystats/etc/job-server.env
+Environment=PATH=/opt/streamystats/nodeenv/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
+Type=simple
+WorkingDirectory=/opt/streamystats/src/apps/job-server
+ExecStart=/opt/streamystats/nodeenv/bin/pnpm start
+User=streamystats
+Group=streamystats
+PrivateTmp=true
+SyslogIdentifier=streamystats-job-server
+StandardOutput=journal
+StandardError=journal
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+
+cat > /lib/systemd/system/streamystats-nextjs-app.service << EOF
+[Unit]
+Description=Streamystats is a statistics service for Jellyfin, providing analytics and data visualization.
+Requires=network-online.target
+#Requires=sssd.service
+Requires=streamystats-job-server.service
+
+[Service]
+EnvironmentFile=/opt/streamystats/etc/db.env
+EnvironmentFile=/opt/streamystats/etc/nextjs-app.env
+Environment=PATH=/opt/streamystats/nodeenv/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
+Environment=NEXT_TELEMETRY_DISABLED=1
+Type=simple
+WorkingDirectory=/opt/streamystats/src/apps/nextjs-app
+ExecStart=/opt/streamystats/nodeenv/bin/pnpm start
+User=streamystats
+Group=streamystats
+PrivateTmp=true
+SyslogIdentifier=streamystats-nextjs-app
+StandardOutput=journal
+StandardError=journal
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now streamystats-db-migration.service
+systemctl enable --now streamystats-job-server.service
+systemctl enable --now streamystats-nextjs-app.service
+```

--- a/DOCKERLESS.md
+++ b/DOCKERLESS.md
@@ -54,7 +54,7 @@ echo 'CREATE EXTENSION IF NOT EXISTS "vector";' | sudo -u postgres psql -d ${DB_
 
 Everything except the database and systemd unit will be contained within `/opt/streamystats`. We will also use a nodeenv to keep everything separate from the system's default node.
 
-### Prepareing the nodeenv
++### Preparing the nodeenv
 Creating the nodeenv:
 ```bash
 [ -d /opt/streamystats/nodeenv ] || nodeenv --prebuilt -n 23.11.1 /opt/streamystats/nodeenv

--- a/DOCKERLESS.md
+++ b/DOCKERLESS.md
@@ -9,7 +9,7 @@ Streamystats depends on the vector extension so you might need to use the upstre
 
 Installing PostgreSQL:
 ```bash
-# NOTE: on Debian Bookwarm the default postgresql version is 15
+# NOTE: on Debian Bookworm, the default PostgreSQL version is 15.
 apt install postgresql postgresql-client
 systemctl enable --now postgresql@15-main.service
 ```

--- a/DOCKERLESS.md
+++ b/DOCKERLESS.md
@@ -52,7 +52,7 @@ echo 'CREATE EXTENSION IF NOT EXISTS "vector";' | sudo -u postgres psql -d ${DB_
 
 ## Streamystats
 
-Everything except the database and systemd unit will be contain within `/opt/streamystats`, we will also use a nodeenv to keep everything seperate from the systems default node.
+Everything except the database and systemd unit will be contained within `/opt/streamystats`. We will also use a nodeenv to keep everything separate from the system's default node.
 
 ### Prepareing the nodeenv
 Creating the nodeenv:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Version tags (e.g., `v1.2.3`) are automatically generated on release. These tags
 
 The `:edge` tag always points to the latest commit on the main branch. It contains the most recent features and fixes. While typically stable, it may occasionally contain breaking changes
 
+### Dockerless
+
+Docker is currently the easiest and recommended way to run streamystats. However you can also run without docker.
+
+[See the documentation](DOCKERLESS.md)
+
 ## 📸 Screenshots
 <img width="1545" alt="Screenshot 2024-11-06 at 21 29 48" src="https://github.com/user-attachments/assets/78c5843a-7dc4-4485-bfeb-841725b133e7">
 <img width="1545" alt="Screenshot 2024-11-06 at 21 30 01" src="https://github.com/user-attachments/assets/d2d4bf6d-85a0-4c6d-8e2b-19e876dc6579">


### PR DESCRIPTION
With the latest set of PRs merge we can now run without docker as requested in https://github.com/fredrikburmester/streamystats/issues/137 (and as something I personally wanted to do)

I'd still recommend most people run it in docker though, but when reverse proxying with a different basePath. Running dockerless is the only way (as you need to set NEXT_PUBLIC_BASE_PATH before running `pnpm build`.

## Summary by Sourcery

Add documentation for running streamystats without Docker by introducing a dedicated Dockerless installation guide and linking it in the README.

Enhancements:
- Enable Dockerless setup by providing a manual installation guide

Documentation:
- Add DOCKERLESS.md with step-by-step instructions for setting up PostgreSQL, building, configuring, and running streamystats without Docker
- Update README.md to include a Dockerless section and link to the new guide