### PR TITLE
fix: set min width and height for play and pause icon on ActiveSession card

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/ActiveSessions.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/ActiveSessions.tsx
@@ -172,9 +172,9 @@ export function ActiveSessions({ server }: { server: Server }) {
                       <div className="flex flex-wrap items-center gap-2 min-w-0 sm:flex-nowrap sm:justify-between">
                         <div className="flex items-center gap-2 min-w-0">
                           {session.isPaused ? (
-                            <Pause className="h-4 w-4 text-amber-500" />
+                            <Pause className="h-4 w-4 min-h-4 min-w-4 text-amber-500" />
                           ) : (
-                            <Play className="h-4 w-4 text-green-500" />
+                            <Play className="h-4 w-4 min-h-4 min-w-4 text-green-500" />
                           )}
                           <h3 className="font-semibold text-lg truncate">
                             {session.item?.name || "Unknown"}


### PR DESCRIPTION
Setting the min width and height seems to fix the issue.

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/e312ada9-20fe-4e20-9053-b688df5e93d7" />


Fixes: #208

## Summary by Sourcery

Bug Fixes:
- Add min-w-4 and min-h-4 classes to Play and Pause icons to ensure consistent dimensions