### PR TITLE
fix: align TZ defaulting to be the same timezone

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
@@ -35,7 +35,7 @@ interface Props {
   data: IWatchTimePerHour[];
 }
 
-const TIMEZONE = process.env.TZ || "Europe/London";
+const TIMEZONE = process.env.TZ || "Europe/Stockholm";
 
 export const WatchTimePerHour: React.FC<Props> = ({
   title,

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/WatchTimePerHour.tsx
@@ -35,7 +35,7 @@ interface Props {
   data: IWatchTimePerHour[];
 }
 
-const TIMEZONE = process.env.TZ || "Europe/Stockholm";
+const TIMEZONE = process.env.TZ || "Etc/UTC";
 
 export const WatchTimePerHour: React.FC<Props> = ({
   title,

--- a/apps/nextjs-app/lib/timezone.ts
+++ b/apps/nextjs-app/lib/timezone.ts
@@ -1,8 +1,8 @@
 import { format, fromUnixTime } from "date-fns";
 import { fromZonedTime, toZonedTime, getTimezoneOffset } from "date-fns-tz";
 
-// Get the timezone from environment or default to 'Europe/Stockholm'
-export const TIMEZONE = process.env.TZ || "Europe/Stockholm";
+// Get the timezone from environment or default to 'Etc/UTC'
+export const TIMEZONE = process.env.TZ || "Etc/UTC";
 
 /**
  * Converts a UTC hour to the local hour in the configured timezone


### PR DESCRIPTION
I think UTC is a safer default than Europe/Stockholm, but at the very lease the defaults should be the same and not Europe/Stockholm + Europe/London.

Depend on your preference we can drop the 2nd commit.

## Summary by Sourcery

Align default timezone settings to UTC across the application

Enhancements:
- Change default TZ in timezone util from Europe/Stockholm to Etc/UTC
- Change default TZ in WatchTimePerHour component from Europe/London to Etc/UTC