### PR TITLE
Enable secure docker image publishing for fork prs

### DIFF
--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -56,23 +56,39 @@ jobs:
     steps:
       - name: PR Build Summary
         run: |
-          echo "## ✅ PR Docker Build Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PR Number:** \`#${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**PR Title:** \`${{ github.event.pull_request.title }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit SHA:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Build Status:" >> $GITHUB_STEP_SUMMARY
-          echo "All Docker images built successfully (not pushed to registry)." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### To Publish Images:" >> $GITHUB_STEP_SUMMARY
-          echo "A maintainer can publish these images by:" >> $GITHUB_STEP_SUMMARY
-          echo "1. Go to **Actions** → **Publish PR Images**" >> $GITHUB_STEP_SUMMARY
-          echo "2. Click **Run workflow**" >> $GITHUB_STEP_SUMMARY
-          echo "3. Enter PR number: \`${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "4. Approve the deployment when prompted" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.build.result }}" == "success" ]; then
+            echo "## ✅ PR Docker Build Complete" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Number:** \`#${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Title:** \`${{ github.event.pull_request.title }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit SHA:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Build Status:" >> $GITHUB_STEP_SUMMARY
+            echo "All Docker images built successfully (not pushed to registry)." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Built Images:" >> $GITHUB_STEP_SUMMARY
+            echo "- \`streamystats-v2-nextjs:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`streamystats-v2-job-server:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`streamystats-v2-migrate:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### To Publish Images:" >> $GITHUB_STEP_SUMMARY
+            echo "A maintainer can publish these images by running the [Publish PR Images workflow](https://github.com/${{ github.repository }}/actions/workflows/publish-pr-images.yml):" >> $GITHUB_STEP_SUMMARY
+            echo "1. Click **Run workflow**" >> $GITHUB_STEP_SUMMARY
+            echo "2. Enter PR number: \`${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. Approve the deployment when prompted" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ❌ PR Docker Build Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Number:** \`#${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Title:** \`${{ github.event.pull_request.title }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit SHA:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Build Status:" >> $GITHUB_STEP_SUMMARY
+            echo "One or more Docker images failed to build. Check the build logs for details." >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Add PR comment
+        if: needs.build.result == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -85,11 +101,10 @@ jobs:
             **Note:** Images are not automatically pushed to Docker Hub for security reasons.
 
             ### For Maintainers:
-            To publish these images for testing, run the [Publish PR Images](../actions/workflows/publish-pr-images.yml) workflow:
-            1. Go to **Actions** → **Publish PR Images**
-            2. Click **Run workflow**
-            3. Enter PR number: \`${prNumber}\`
-            4. Approve the environment deployment
+            To publish these images for testing, run the [**Publish PR Images** workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/publish-pr-images.yml):
+            1. Click **Run workflow**
+            2. Enter PR number: \`${prNumber}\`
+            3. Approve the environment deployment
 
             This will publish:
             - \`streamystats-v2-nextjs:pr-${prNumber}\`
@@ -104,7 +119,47 @@ jobs:
 
             const existingComment = comments.data.find(comment => 
               comment.user.login === 'github-actions[bot]' && 
-              comment.body.includes('PR Docker Build Complete')
+              comment.body.includes('PR Docker Build')
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+            }
+
+      - name: Add PR comment on failure
+        if: needs.build.result != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.number;
+
+            const comment = `## ❌ PR Docker Build Failed
+
+            One or more Docker images failed to build. Please check the [workflow logs](../actions/runs/${{ github.run_id }}) for details.
+
+            **Build Result:** \`${{ needs.build.result }}\``;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('PR Docker Build')
             );
 
             if (existingComment) {

--- a/.github/workflows/publish-pr-images.yml
+++ b/.github/workflows/publish-pr-images.yml
@@ -61,13 +61,27 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ inputs.pr }}
-            });
-            core.setOutput('sha', pr.data.head.sha);
-            core.setOutput('updated_at', pr.data.updated_at);
+            try {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: ${{ inputs.pr }}
+              });
+              
+              if (pr.data.state !== 'open') {
+                core.setFailed(`PR #${{ inputs.pr }} is ${pr.data.state}. Only open PRs can be published.`);
+                return;
+              }
+              
+              core.setOutput('sha', pr.data.head.sha);
+              core.setOutput('updated_at', pr.data.updated_at);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(`PR #${{ inputs.pr }} does not exist.`);
+              } else {
+                core.setFailed(`Failed to fetch PR metadata: ${error.message}`);
+              }
+            }
 
       - name: Build & push ${{ matrix.part }}
         uses: docker/build-push-action@v5
@@ -91,24 +105,36 @@ jobs:
     steps:
       - name: Build Summary
         run: |
-          echo "## 🚀 PR Images Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PR Number:** \`#${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Namespace:** \`${{ env.IMAGE_NAMESPACE }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published Images:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-nextjs:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-job-server:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-migrate:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "export VERSION=pr-${{ inputs.pr }}" >> $GITHUB_STEP_SUMMARY
-          echo "docker-compose up -d" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.publish.result }}" == "success" ]; then
+            echo "## 🚀 PR Images Published" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Number:** \`#${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Namespace:** \`${{ env.IMAGE_NAMESPACE }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Published Images:" >> $GITHUB_STEP_SUMMARY
+            echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-nextjs:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-job-server:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-migrate:pr-${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Usage:" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "export VERSION=pr-${{ inputs.pr }}" >> $GITHUB_STEP_SUMMARY
+            echo "docker-compose up -d" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ❌ PR Images Publish Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**PR Number:** \`#${{ inputs.pr }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Namespace:** \`${{ env.IMAGE_NAMESPACE }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Publish Status:" >> $GITHUB_STEP_SUMMARY
+            echo "One or more images failed to publish. Check the publish logs for details." >> $GITHUB_STEP_SUMMARY
+          fi
 
-      - name: Add PR comment
+      - name: Add PR comment on success
+        if: needs.publish.result == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -140,7 +166,47 @@ jobs:
 
             const existingComment = comments.data.find(comment => 
               comment.user.login === 'github-actions[bot]' && 
-              comment.body.includes('PR Docker Images Published')
+              comment.body.includes('PR Docker Images')
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+            }
+
+      - name: Add PR comment on failure
+        if: needs.publish.result != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ inputs.pr }};
+
+            const comment = `## ❌ PR Docker Images Publish Failed
+
+            One or more images failed to publish. Please check the [workflow logs](../actions/runs/${{ github.run_id }}) for details.
+
+            **Publish Result:** \`${{ needs.publish.result }}\``;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('PR Docker Images')
             );
 
             if (existingComment) {


### PR DESCRIPTION
Implement a secure two-workflow system to allow external fork PRs to build Docker images and enable maintainers to manually publish them.

This solution separates the build validation (safe for all PRs, no secrets) from the image publishing (maintainer-gated, uses secrets), preventing secret exposure to untrusted fork PRs while still providing a mechanism to get build artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffb0d702-d83c-47fa-8cd9-d5aee6480102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffb0d702-d83c-47fa-8cd9-d5aee6480102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Implement a secure two-workflow system that separates image building for all pull requests from a maintainer-gated image publishing process to prevent secret exposure while enabling artifact access.

New Features:
- Add manual 'Publish PR Images' workflow to build and push Docker images for specified PRs using repository secrets

Enhancements:
- Update PR build summary and issue comments to reflect non-pushing builds and guide maintainers on manual image publishing steps

CI:
- Refactor PR Docker build workflow to only build images without pushing and remove secret usage for external PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors PR Docker workflow to build images without pushing and adds a maintainer-triggered workflow to publish PR images securely.
> 
> - **Workflows**:
>   - **PR Docker Build (`.github/workflows/pr-docker-build.yml`)**:
>     - Build-only: removes registry login/push; builds multi-arch images with `push: false` and local tags `matrix.part:pr-${{ github.event.number }}`.
>     - Simplifies job (`build`) and updates metadata args to use PR context directly.
>     - Adds result-aware step summary and PR comments (success/failure) guiding maintainers to manual publish.
>   - **Publish PR Images (`.github/workflows/publish-pr-images.yml`)**:
>     - New manual `workflow_dispatch` to build and push PR images using secrets and env-protected `pr-publish` environment.
>     - Checks out PR merge ref, fetches PR metadata, builds multi-arch images, and pushes to `${{ secrets.DOCKER_USERNAME }}` namespace with tag `pr-<PR#>`.
>     - Posts success/failure summaries and PR comments with usage instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78814c509ac3ef79516de90d2a2ad80c96817e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->