### PR TITLE
fix(#248) Enable local IP access for images

### DIFF
--- a/apps/nextjs-app/next.config.mjs
+++ b/apps/nextjs-app/next.config.mjs
@@ -3,6 +3,7 @@ const nextConfig = {
   output: "standalone",
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
   images: {
+    dangerouslyAllowLocalIP: true,
     remotePatterns: [
       {
         protocol: "http",


### PR DESCRIPTION
This fixes https://github.com/fredrikburmester/streamystats/issues/248 it restores the behavior from before the nextjs v16 update.

Like myself, I image many might run there jellyfin with split-dns where the internet facing FQDN resolves to a public IP but internally it resolves to a private IP, this change will allow 'private ranges' to be used again by the image proxy/processor.

## Summary by Sourcery

Bug Fixes:
- Restore support for image loading when using split-DNS setups that resolve to private IPs.