### PR TITLE
fx: change health check urls to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
           "--quiet",
           "--tries=1",
           "--spider",
-          "http://localhost:3000/api/health",
+          "http://127.0.0.1:3000/api/health",
         ]
       interval: 30s
       timeout: 10s
@@ -77,7 +77,7 @@ services:
           "--quiet",
           "--tries=1",
           "--spider",
-          "http://localhost:3005/health",
+          "http://127.0.0.1:3005/health",
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
Change Docker health checks to use _127.0.0.1_ instead of _localhost_, as localhost gets rejected within the nextjs-app.
resolves #268

## Summary by Sourcery

Bug Fixes:
- Fix health check failures in the Next.js app by switching from localhost to 127.0.0.1 in Docker health check URLs.