### PR TITLE
fix: update healthcheck to use 127.0.0.1 and remove redundant Docker compose health checks

### DIFF
--- a/apps/nextjs-app/Dockerfile
+++ b/apps/nextjs-app/Dockerfile
@@ -74,7 +74,7 @@ USER nextjs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD wget -q -O /dev/null http://localhost:3000/api/health || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
 WORKDIR /app/apps/nextjs-app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,20 +38,6 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     logging: *default-logging
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://localhost:3000/api/health",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
     networks:
       - app-network
 
@@ -69,20 +55,6 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     logging: *default-logging
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://localhost:3005/health",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
     networks:
       - app-network
 


### PR DESCRIPTION
Remove redundant Docker health checks and use 127.0.0.1 instead of localhost within nextjs-app, as localhost gets rejected.
Resolves #268

## Summary by Sourcery

Update container health checking by relying on the Next.js app Docker healthcheck and dropping redundant docker-compose health checks.

Bug Fixes:
- Use 127.0.0.1 instead of localhost for the Next.js app Docker healthcheck to ensure the health endpoint is reachable from within the container.

Enhancements:
- Simplify docker-compose configuration by removing redundant service-level health checks now covered by the application container healthcheck.