### PR TITLE
refactor: use node for nextjs try to minimize memory usage

### DIFF
--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -65,6 +65,11 @@ RUN --mount=type=cache,target=/app/apps/nextjs-app/.next/cache \
     bun --bun next build --experimental-build-mode compile
 
 # ============================================
+# Node.js runtime (pinned)
+# ============================================
+FROM node:24-bookworm-slim AS node-runtime
+
+# ============================================
 # Production runtime - Based on VectorChord PostgreSQL
 # ============================================
 FROM tensorchord/vchord-postgres:pg17-v0.4.1 AS runner
@@ -78,9 +83,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Bun runtime
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:$PATH"
+# Copy Node.js runtime (pinned)
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 
 WORKDIR /app
 

--- a/apps/nextjs-app/Dockerfile
+++ b/apps/nextjs-app/Dockerfile
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/app/apps/nextjs-app/.next/cache \
     bun --bun next build --experimental-build-mode compile
 
 # Production runtime stage
-FROM oven/bun:1.3.5-alpine AS runner
+FROM node:24-alpine AS runner
 
 RUN apk add --no-cache libc6-compat vips curl
 
@@ -78,4 +78,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 WORKDIR /app/apps/nextjs-app
 
-CMD ["bun", "run", "server.js"]
+CMD ["node", "server.js"]

--- a/docker/aio/scripts/nextjs-wrapper.sh
+++ b/docker/aio/scripts/nextjs-wrapper.sh
@@ -5,5 +5,5 @@ until curl -sf http://localhost:3005/health >/dev/null 2>&1; do
 done
 echo "[AIO] Starting Next.js..."
 cd /app/apps/nextjs-app
-exec /root/.bun/bin/bun run server.js
+exec node server.js
 


### PR DESCRIPTION
## Summary by Sourcery

Switch the Next.js app runtime from Bun to Node.js to reduce memory usage and align Docker and wrapper scripts with the new runtime.

Build:
- Update the Next.js Dockerfile to use a Node.js Alpine image for the production runtime and start the app with node instead of bun.

Deployment:
- Adjust the AIO Docker wrapper script to start the Next.js server with Node.js instead of Bun.