### PR TITLE
fix: disable cache to prevent memory leak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - JOB_SERVER_URL=http://job-server:3005
       - HOSTNAME=0.0.0.0
       - SESSION_SECRET=${SESSION_SECRET}
+      - NEXT_DISABLE_CACHE=1
     depends_on:
       vectorchord:
         condition: service_healthy


### PR DESCRIPTION
Add NEXT_DISABLE_CACHE=1 environment variable to docker-compose.yml to address cache-related memory leak issues.

This is not meant to be a final fix (since it is slower) but a temporal workaround for the memory leak.
PR created just for awareness. Created a draft

## Summary by Sourcery

Build:
- Add NEXT_DISABLE_CACHE=1 environment variable to the docker-compose service to turn off caching at runtime.