### PR TITLE
feat: add OCI source label to Docker images for Renovatebot support

### DIFF
--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -125,6 +125,8 @@ ENV POSTGRES_DB=streamystats
 ENV DATABASE_URL=postgresql://postgres:postgres@localhost:5432/streamystats
 ENV PGDATA=/var/lib/postgresql/data
 
+LABEL org.opencontainers.image.source="https://github.com/fredrikburmester/streamystats"
+
 # Expose port (only web UI needed externally)
 EXPOSE 3000
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -19,3 +19,5 @@ COPY packages/database ./packages/database
 
 WORKDIR /app/packages/database
 RUN bun run build
+
+LABEL org.opencontainers.image.source="https://github.com/fredrikburmester/streamystats"

--- a/apps/job-server/Dockerfile
+++ b/apps/job-server/Dockerfile
@@ -51,6 +51,8 @@ ENV NODE_ENV=production
 ENV PORT=3005
 ENV HOST=0.0.0.0
 
+LABEL org.opencontainers.image.source="https://github.com/fredrikburmester/streamystats"
+
 EXPOSE 3005
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \

--- a/apps/nextjs-app/Dockerfile
+++ b/apps/nextjs-app/Dockerfile
@@ -64,6 +64,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 
+LABEL org.opencontainers.image.source="https://github.com/fredrikburmester/streamystats"
+
 # Copy standalone build
 COPY --from=nextjs-builder --chown=nextjs:nodejs /app/apps/nextjs-app/.next/standalone ./
 COPY --from=nextjs-builder --chown=nextjs:nodejs /app/apps/nextjs-app/.next/static ./apps/nextjs-app/.next/static

--- a/migration.Dockerfile
+++ b/migration.Dockerfile
@@ -39,5 +39,7 @@ COPY --from=builder /app/packages/database/drizzle ./drizzle
 
 ENV NODE_ENV=production
 
+LABEL org.opencontainers.image.source="https://github.com/fredrikburmester/streamystats"
+
 # Run the binary
 CMD ["./migrate-bin"]


### PR DESCRIPTION
Add `org.opencontainers.image.source` label to all Dockerfiles (which enables Renovatebot and other similar bots to automatically find changelogs when opening PRs) 

Closes #276

## Summary by Sourcery

Enhancements:
- Add org.opencontainers.image.source label to the job server, Next.js app, and migration Dockerfiles to link images back to the GitHub repository.