### PR TITLE
fix: reduce sync frequency and fix repeated item updates

### DIFF
--- a/apps/job-server/src/jobs/scheduler.ts
+++ b/apps/job-server/src/jobs/scheduler.ts
@@ -13,16 +13,16 @@ class SyncScheduler {
   private scheduledTasks: Map<string, cron.ScheduledTask> = new Map();
   private enabled: boolean = false;
   private activitySyncInterval: string =
-    Bun.env.CRON_ACTIVITY_SYNC || "*/1 * * * *"; // Every minute
+    Bun.env.CRON_ACTIVITY_SYNC || "*/5 * * * *"; // Every 5 minutes
   private recentItemsSyncInterval: string =
-    Bun.env.CRON_RECENT_ITEMS_SYNC || "*/1 * * * *"; // Every minute
-  private userSyncInterval: string = Bun.env.CRON_USER_SYNC || "*/1 * * * *"; // Every minute
+    Bun.env.CRON_RECENT_ITEMS_SYNC || "*/5 * * * *"; // Every 5 minutes
+  private userSyncInterval: string = Bun.env.CRON_USER_SYNC || "*/5 * * * *"; // Every 5 minutes
   private peopleSyncInterval: string =
-    Bun.env.CRON_PEOPLE_SYNC || "*/15 * * * *"; // Every 15 minutes
+    Bun.env.CRON_PEOPLE_SYNC || "*/15 * * * *"; // Every hour
   private embeddingsSyncInterval: string =
     Bun.env.CRON_EMBEDDINGS_SYNC || "*/15 * * * *"; // Every 15 minutes
   private geolocationSyncInterval: string =
-    Bun.env.CRON_GEOLOCATION_SYNC || "*/5 * * * *"; // Every 5 minutes
+    Bun.env.CRON_GEOLOCATION_SYNC || "*/15 * * * *"; // Every 5 minutes
   private fingerprintSyncInterval: string =
     Bun.env.CRON_FINGERPRINT_SYNC || "0 4 * * *"; // Daily at 4 AM
   private jobCleanupInterval: string =


### PR DESCRIPTION
- Change default sync intervals from 1 min to 5 min (activity, recent-items, users)
- Fix `hasImageFieldsChanged` using deep comparison instead of `JSON.stringify` to handle inconsistent key ordering
- Skip deleted-items cleanup for libraries that fail to fetch (prevents false deletions on timeout)

## Summary by Sourcery

Adjust sync scheduling intervals and harden Jellyfin sync logic against unnecessary item updates and false deletions.

Bug Fixes:
- Prevent image-related items from being treated as changed when only object key ordering differs by using a deep equality check for complex image fields.
- Avoid marking items as deleted for Jellyfin libraries whose contents could not be fetched by skipping deletion processing for failed libraries and logging these cases.

Enhancements:
- Relax default sync cron intervals for activity, recent items, users, people, and geolocation jobs to reduce sync frequency and load.