### PR TITLE
fix: move params await inside Suspense to avoid blocking route

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/login/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/login/page.tsx
@@ -9,16 +9,15 @@ export default async function Page({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-
   return (
     <Suspense fallback={<LoginSkeleton />}>
-      <LoginContent id={id} />
+      <LoginContent params={params} />
     </Suspense>
   );
 }
 
-async function LoginContent({ id }: { id: string }) {
+async function LoginContent({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const server = await getServer({ serverId: id });
   const servers = await getServers();
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Avoid blocking the server login route rendering by moving the params await into the Suspense-wrapped LoginContent component.