### PR TITLE
fix: strip trailing slashes from AI base URLs

### DIFF
--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -183,9 +183,12 @@ export const saveEmbeddingConfig = async ({
   try {
     // Build update object - only include apiKey if explicitly provided
     // This prevents accidentally wiping existing keys when other fields are updated
+    // Normalize base URL by removing trailing slashes
+    const normalizedBaseUrl = config.baseUrl?.replace(/\/+$/, "");
+
     const updateData: Partial<typeof servers.$inferInsert> = {
       embeddingProvider: config.provider,
-      embeddingBaseUrl: config.baseUrl,
+      embeddingBaseUrl: normalizedBaseUrl,
       embeddingModel: config.model,
       embeddingDimensions: config.dimensions || 1536,
     };
@@ -847,9 +850,12 @@ export const saveChatConfig = async ({
   try {
     // Build update object - only include apiKey if explicitly provided
     // This prevents accidentally wiping existing keys when other fields are updated
+    // Normalize base URL by removing trailing slashes
+    const normalizedBaseUrl = config.baseUrl?.replace(/\/+$/, "");
+
     const updateData: Partial<typeof servers.$inferInsert> = {
       chatProvider: config.provider,
-      chatBaseUrl: config.baseUrl,
+      chatBaseUrl: normalizedBaseUrl,
       chatModel: config.model,
     };
 


### PR DESCRIPTION
## Summary
- Automatically removes trailing slashes from base URLs when saving embedding and chat configurations
- Prevents connection failures when users enter URLs with trailing slashes (e.g., Google's Gemini API documentation includes URLs ending with `/`)

Fixes #324

## Summary by Sourcery

Bug Fixes:
- Strip trailing slashes from embedding and chat base URLs before persisting them to avoid connection failures with APIs that reject trailing slashes.