### PR TITLE
feat: people statistics

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/DirectorActorCombinations.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/DirectorActorCombinations.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Users } from "lucide-react";
+import Link from "next/link";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import type { DirectorActorCombination } from "@/lib/db/people-stats";
+import type { ServerPublic } from "@/lib/types";
+import { formatDuration } from "@/lib/utils";
+
+interface Props {
+  combinations: DirectorActorCombination[];
+  server: ServerPublic;
+}
+
+function CombinationCard({
+  combination,
+  server,
+}: {
+  combination: DirectorActorCombination;
+  server: ServerPublic;
+}) {
+  return (
+    <div className="flex-shrink-0 w-[200px] rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:shadow-lg transition-all duration-200">
+      <div className="flex flex-col gap-2">
+        <Link
+          href={`/servers/${server.id}/actors/${encodeURIComponent(combination.directorId)}`}
+          className="hover:text-primary transition-colors"
+        >
+          <p className="text-xs text-muted-foreground">Director</p>
+          <p
+            className="text-sm font-semibold truncate"
+            title={combination.directorName}
+          >
+            {combination.directorName}
+          </p>
+        </Link>
+        <div className="text-xs text-muted-foreground text-center">+</div>
+        <Link
+          href={`/servers/${server.id}/actors/${encodeURIComponent(combination.actorId)}`}
+          className="hover:text-primary transition-colors"
+        >
+          <p className="text-xs text-muted-foreground">Actor</p>
+          <p
+            className="text-sm font-semibold truncate"
+            title={combination.actorName}
+          >
+            {combination.actorName}
+          </p>
+        </Link>
+      </div>
+      <div className="mt-3 pt-3 border-t border-border">
+        <p className="text-xs font-medium text-primary">
+          {formatDuration(combination.totalWatchTime)}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {combination.itemCount}{" "}
+          {combination.itemCount === 1 ? "title" : "titles"} together
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function DirectorActorCombinations({ combinations, server }: Props) {
+  if (!combinations || combinations.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="p-1.5 rounded-lg bg-primary/10">
+            <Users className="h-4 w-4 text-primary" />
+          </div>
+          <h2 className="text-lg font-semibold">
+            Popular Director + Actor Combinations
+          </h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          No director-actor combinations found yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="p-4 pb-3">
+        <h2 className="text-lg font-bold flex items-center gap-2">
+          <div className="p-1.5 rounded-lg bg-primary/10">
+            <Users className="h-4 w-4 text-primary" />
+          </div>
+          Popular Director + Actor Combinations
+        </h2>
+        <p className="text-xs text-muted-foreground mt-1">
+          Most watched director and actor pairings
+        </p>
+      </div>
+
+      <ScrollArea dir="ltr" className="w-full py-1">
+        <div className="flex gap-4 flex-nowrap px-4 pb-4 w-max">
+          {combinations.map((combo) => (
+            <CombinationCard
+              key={`${combo.directorId}-${combo.actorId}`}
+              combination={combo}
+              server={server}
+            />
+          ))}
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Clock, Film, Play, TrendingUp } from "lucide-react";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import type { PersonStats } from "@/lib/db/people-stats";
+import type { ServerPublic } from "@/lib/types";
+import { PersonCard } from "./PersonCard";
+
+export type IconType = "clock" | "play" | "film" | "trending";
+
+const iconMap = {
+  clock: Clock,
+  play: Play,
+  film: Film,
+  trending: TrendingUp,
+} as const;
+
+interface Props {
+  title: string;
+  description: string;
+  iconType: IconType;
+  people: PersonStats[];
+  server: ServerPublic;
+  variant: "watchtime" | "playcount";
+  emptyMessage: string;
+}
+
+export function PeopleSection({
+  title,
+  description,
+  iconType,
+  people,
+  server,
+  variant,
+  emptyMessage,
+}: Props) {
+  const Icon = iconMap[iconType];
+
+  if (!people || people.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="p-1.5 rounded-lg bg-primary/10">
+            <Icon className="h-4 w-4 text-primary" />
+          </div>
+          <h2 className="text-lg font-semibold">{title}</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="p-4 pb-3">
+        <h2 className="text-lg font-bold flex items-center gap-2">
+          <div className="p-1.5 rounded-lg bg-primary/10">
+            <Icon className="h-4 w-4 text-primary" />
+          </div>
+          {title}
+        </h2>
+        <p className="text-xs text-muted-foreground mt-1">{description}</p>
+      </div>
+
+      <ScrollArea dir="ltr" className="w-full py-1">
+        <div className="flex gap-4 flex-nowrap px-4 pb-4 w-max">
+          {people.map((person) => (
+            <PersonCard
+              key={person.id}
+              person={person}
+              server={server}
+              variant={variant}
+            />
+          ))}
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
@@ -1,0 +1,79 @@
+import type { MediaTypeFilter } from "@/lib/db/people-stats";
+import {
+  getTopDirectorActorCombinations,
+  getTopPeopleByPlayCount,
+  getTopPeopleByWatchTime,
+} from "@/lib/db/people-stats";
+import type { ServerPublic } from "@/lib/types";
+import { DirectorActorCombinations } from "./DirectorActorCombinations";
+import { PeopleSection } from "./PeopleSection";
+
+interface Props {
+  server: ServerPublic;
+  mediaType: MediaTypeFilter;
+}
+
+export async function PeopleStats({ server, mediaType }: Props) {
+  const [
+    topActorsByWatchTime,
+    topActorsByPlayCount,
+    topDirectorsByWatchTime,
+    topDirectorsByPlayCount,
+    directorActorCombos,
+  ] = await Promise.all([
+    getTopPeopleByWatchTime(server.id, "Actor", mediaType, 20),
+    getTopPeopleByPlayCount(server.id, "Actor", mediaType, 20),
+    getTopPeopleByWatchTime(server.id, "Director", mediaType, 20),
+    getTopPeopleByPlayCount(server.id, "Director", mediaType, 20),
+    getTopDirectorActorCombinations(server.id, mediaType, 15),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PeopleSection
+        title="Top Actors by Watch Time"
+        description="Most watched actors based on total viewing time"
+        iconType="clock"
+        people={topActorsByWatchTime}
+        server={server}
+        variant="watchtime"
+        emptyMessage="No actor statistics available yet. Watch some content to see stats!"
+      />
+
+      <PeopleSection
+        title="Top Actors by Play Count"
+        description="Most frequently watched actors"
+        iconType="play"
+        people={topActorsByPlayCount}
+        server={server}
+        variant="playcount"
+        emptyMessage="No actor statistics available yet."
+      />
+
+      <PeopleSection
+        title="Top Directors by Watch Time"
+        description="Most watched directors based on total viewing time"
+        iconType="film"
+        people={topDirectorsByWatchTime}
+        server={server}
+        variant="watchtime"
+        emptyMessage="No director statistics available yet."
+      />
+
+      <PeopleSection
+        title="Top Directors by Play Count"
+        description="Most frequently watched directors"
+        iconType="trending"
+        people={topDirectorsByPlayCount}
+        server={server}
+        variant="playcount"
+        emptyMessage="No director statistics available yet."
+      />
+
+      <DirectorActorCombinations
+        combinations={directorActorCombos}
+        server={server}
+      />
+    </div>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleTypeTabs.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleTypeTabs.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useQueryParams } from "@/hooks/useQueryParams";
+import type { MediaTypeFilter } from "@/lib/db/people-stats";
+
+interface Props {
+  currentMediaType: MediaTypeFilter;
+}
+
+export function PeopleTypeTabs({ currentMediaType }: Props) {
+  const { updateQueryParams, isLoading } = useQueryParams();
+
+  const handleValueChange = (value: string) => {
+    updateQueryParams({
+      mediaType: value === "all" ? null : value,
+    });
+  };
+
+  return (
+    <Tabs
+      value={currentMediaType}
+      onValueChange={handleValueChange}
+      className="mb-6"
+    >
+      <TabsList>
+        <TabsTrigger value="all" disabled={isLoading}>
+          All
+        </TabsTrigger>
+        <TabsTrigger value="Movie" disabled={isLoading}>
+          Movies
+        </TabsTrigger>
+        <TabsTrigger value="Series" disabled={isLoading}>
+          Series
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { User } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import type { PersonStats } from "@/lib/db/people-stats";
+import type { ServerPublic } from "@/lib/types";
+import { formatDuration } from "@/lib/utils";
+
+interface Props {
+  person: PersonStats;
+  server: ServerPublic;
+  variant: "watchtime" | "playcount";
+}
+
+export function PersonCard({ person, server, variant }: Props) {
+  const [hasError, setHasError] = useState(false);
+
+  const imageUrl = person.primaryImageTag
+    ? `${server.url}/Items/${person.id}/Images/Primary?fillHeight=300&fillWidth=200&quality=96&tag=${person.primaryImageTag}`
+    : null;
+
+  // Generate initials for fallback
+  const initials = person.name
+    .split(" ")
+    .map((n) => n[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  return (
+    <Link
+      href={`/servers/${server.id}/actors/${encodeURIComponent(person.id)}`}
+      className="flex-shrink-0 group"
+    >
+      <div className="w-[140px] rounded-lg border border-border bg-card overflow-hidden hover:border-primary/50 hover:shadow-lg transition-all duration-200">
+        {/* Image section */}
+        <div className="w-full aspect-[2/3] bg-muted relative">
+          {imageUrl && !hasError ? (
+            <Image
+              src={imageUrl}
+              alt={person.name}
+              fill
+              className="object-cover"
+              onError={() => setHasError(true)}
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-muted">
+              {initials ? (
+                <span className="text-2xl font-semibold text-muted-foreground/50">
+                  {initials}
+                </span>
+              ) : (
+                <User className="w-12 h-12 text-muted-foreground/30" />
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Info section */}
+        <div className="p-3">
+          <h3 className="text-sm font-semibold truncate" title={person.name}>
+            {person.name}
+          </h3>
+          <p className="text-xs text-muted-foreground">{person.type}</p>
+          <div className="mt-2">
+            {variant === "watchtime" ? (
+              <p className="text-xs font-medium text-primary">
+                {formatDuration(person.totalWatchTime)}
+              </p>
+            ) : (
+              <p className="text-xs font-medium text-primary">
+                {person.totalPlayCount.toLocaleString()} plays
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {person.itemCount} {person.itemCount === 1 ? "title" : "titles"}
+            </p>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { Container } from "@/components/Container";
+import { PageTitle } from "@/components/PageTitle";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { MediaTypeFilter } from "@/lib/db/people-stats";
+import { getServer } from "@/lib/db/server";
+import { PeopleStats } from "./PeopleStats";
+import { PeopleTypeTabs } from "./PeopleTypeTabs";
+
+export default async function PeoplePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ mediaType?: string }>;
+}) {
+  const { id } = await params;
+  const { mediaType } = await searchParams;
+  const server = await getServer({ serverId: id });
+
+  if (!server) {
+    redirect("/not-found");
+  }
+
+  // Validate mediaType parameter
+  const effectiveMediaType: MediaTypeFilter =
+    mediaType === "Movie" || mediaType === "Series" ? mediaType : "all";
+
+  return (
+    <Container className="flex flex-col">
+      <PageTitle title="People Statistics" />
+      <PeopleTypeTabs currentMediaType={effectiveMediaType} />
+      <Suspense
+        fallback={
+          <div className="flex flex-col gap-6">
+            <Skeleton className="h-72 w-full rounded-lg" />
+            <Skeleton className="h-72 w-full rounded-lg" />
+            <Skeleton className="h-72 w-full rounded-lg" />
+            <Skeleton className="h-72 w-full rounded-lg" />
+            <Skeleton className="h-72 w-full rounded-lg" />
+          </div>
+        }
+      >
+        <PeopleStats server={server} mediaType={effectiveMediaType} />
+      </Suspense>
+    </Container>
+  );
+}

--- a/apps/nextjs-app/components/SideBar.tsx
+++ b/apps/nextjs-app/components/SideBar.tsx
@@ -78,6 +78,11 @@ const dashboard_items = [
     url: "/dashboard/clients",
     icon: Monitor,
   },
+  {
+    title: "People",
+    url: "/dashboard/people",
+    icon: Users,
+  },
 ];
 
 const admin_items = [

--- a/apps/nextjs-app/lib/db/people-stats.ts
+++ b/apps/nextjs-app/lib/db/people-stats.ts
@@ -1,0 +1,597 @@
+"use cache";
+
+import {
+  db,
+  itemPeople,
+  items,
+  people,
+  sessions,
+} from "@streamystats/database";
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  isNotNull,
+  type SQL,
+  sum,
+} from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { getStatisticsExclusions } from "./exclusions";
+
+export interface PersonStats {
+  id: string;
+  name: string;
+  primaryImageTag: string | null;
+  type: "Actor" | "Director";
+  totalWatchTime: number;
+  totalPlayCount: number;
+  itemCount: number;
+}
+
+export interface DirectorActorCombination {
+  directorId: string;
+  directorName: string;
+  directorImageTag: string | null;
+  actorId: string;
+  actorName: string;
+  actorImageTag: string | null;
+  totalWatchTime: number;
+  totalPlayCount: number;
+  itemCount: number;
+}
+
+export type MediaTypeFilter = "all" | "Movie" | "Series";
+
+/**
+ * Get top people (actors or directors) by total watch time.
+ *
+ * For Movies: sessions → items (Movie) → item_people → people
+ * For Series: sessions → items (Episode) → item_people (on seriesId) → people
+ */
+export async function getTopPeopleByWatchTime(
+  serverId: string | number,
+  personType: "Actor" | "Director",
+  mediaType: MediaTypeFilter,
+  limit = 20,
+): Promise<PersonStats[]> {
+  "use cache";
+  const serverIdNum = Number(serverId);
+  cacheLife("hours");
+  cacheTag(`people-watchtime-${serverIdNum}-${personType}-${mediaType}`);
+
+  const { userExclusion, itemLibraryExclusion } =
+    await getStatisticsExclusions(serverId);
+
+  const results: PersonStats[] = [];
+
+  // Query for Movies
+  if (mediaType === "all" || mediaType === "Movie") {
+    const movieConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Movie"),
+      eq(itemPeople.type, personType),
+    ];
+
+    if (userExclusion) {
+      movieConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      movieConditions.push(itemLibraryExclusion);
+    }
+
+    const movieStats = await db
+      .select({
+        personId: people.id,
+        personName: people.name,
+        primaryImageTag: people.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.id).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(itemPeople, eq(items.id, itemPeople.itemId))
+      .innerJoin(
+        people,
+        and(
+          eq(itemPeople.personId, people.id),
+          eq(itemPeople.serverId, people.serverId),
+        ),
+      )
+      .where(and(...movieConditions))
+      .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
+      .orderBy(desc(sum(sessions.playDuration)))
+      .limit(limit);
+
+    for (const stat of movieStats) {
+      results.push({
+        id: stat.personId,
+        name: stat.personName,
+        primaryImageTag: stat.primaryImageTag,
+        type: personType,
+        totalWatchTime: Number(stat.totalWatchTime ?? 0),
+        totalPlayCount: Number(stat.totalPlayCount),
+        itemCount: Number(stat.itemCount),
+      });
+    }
+  }
+
+  // Query for Series (aggregate from episodes)
+  if (mediaType === "all" || mediaType === "Series") {
+    const seriesConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Episode"),
+      isNotNull(items.seriesId),
+      eq(itemPeople.type, personType),
+    ];
+
+    if (userExclusion) {
+      seriesConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      seriesConditions.push(itemLibraryExclusion);
+    }
+
+    // For series: join item_people on the seriesId (cast is on Series, not Episode)
+    const seriesStats = await db
+      .select({
+        personId: people.id,
+        personName: people.name,
+        primaryImageTag: people.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.seriesId).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(itemPeople, eq(items.seriesId, itemPeople.itemId))
+      .innerJoin(
+        people,
+        and(
+          eq(itemPeople.personId, people.id),
+          eq(itemPeople.serverId, people.serverId),
+        ),
+      )
+      .where(and(...seriesConditions))
+      .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
+      .orderBy(desc(sum(sessions.playDuration)))
+      .limit(limit);
+
+    for (const stat of seriesStats) {
+      // If mediaType is "all", merge with movie stats
+      if (mediaType === "all") {
+        const existing = results.find((r) => r.id === stat.personId);
+        if (existing) {
+          existing.totalWatchTime += Number(stat.totalWatchTime ?? 0);
+          existing.totalPlayCount += Number(stat.totalPlayCount);
+          existing.itemCount += Number(stat.itemCount);
+        } else {
+          results.push({
+            id: stat.personId,
+            name: stat.personName,
+            primaryImageTag: stat.primaryImageTag,
+            type: personType,
+            totalWatchTime: Number(stat.totalWatchTime ?? 0),
+            totalPlayCount: Number(stat.totalPlayCount),
+            itemCount: Number(stat.itemCount),
+          });
+        }
+      } else {
+        results.push({
+          id: stat.personId,
+          name: stat.personName,
+          primaryImageTag: stat.primaryImageTag,
+          type: personType,
+          totalWatchTime: Number(stat.totalWatchTime ?? 0),
+          totalPlayCount: Number(stat.totalPlayCount),
+          itemCount: Number(stat.itemCount),
+        });
+      }
+    }
+  }
+
+  // Sort by watch time and limit
+  results.sort((a, b) => b.totalWatchTime - a.totalWatchTime);
+  return results.slice(0, limit);
+}
+
+/**
+ * Get top people (actors or directors) by play count.
+ */
+export async function getTopPeopleByPlayCount(
+  serverId: string | number,
+  personType: "Actor" | "Director",
+  mediaType: MediaTypeFilter,
+  limit = 20,
+): Promise<PersonStats[]> {
+  "use cache";
+  const serverIdNum = Number(serverId);
+  cacheLife("hours");
+  cacheTag(`people-playcount-${serverIdNum}-${personType}-${mediaType}`);
+
+  const { userExclusion, itemLibraryExclusion } =
+    await getStatisticsExclusions(serverId);
+
+  const results: PersonStats[] = [];
+
+  // Query for Movies
+  if (mediaType === "all" || mediaType === "Movie") {
+    const movieConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Movie"),
+      eq(itemPeople.type, personType),
+    ];
+
+    if (userExclusion) {
+      movieConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      movieConditions.push(itemLibraryExclusion);
+    }
+
+    const movieStats = await db
+      .select({
+        personId: people.id,
+        personName: people.name,
+        primaryImageTag: people.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.id).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(itemPeople, eq(items.id, itemPeople.itemId))
+      .innerJoin(
+        people,
+        and(
+          eq(itemPeople.personId, people.id),
+          eq(itemPeople.serverId, people.serverId),
+        ),
+      )
+      .where(and(...movieConditions))
+      .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
+      .orderBy(desc(count(sessions.id)))
+      .limit(limit);
+
+    for (const stat of movieStats) {
+      results.push({
+        id: stat.personId,
+        name: stat.personName,
+        primaryImageTag: stat.primaryImageTag,
+        type: personType,
+        totalWatchTime: Number(stat.totalWatchTime ?? 0),
+        totalPlayCount: Number(stat.totalPlayCount),
+        itemCount: Number(stat.itemCount),
+      });
+    }
+  }
+
+  // Query for Series
+  if (mediaType === "all" || mediaType === "Series") {
+    const seriesConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Episode"),
+      isNotNull(items.seriesId),
+      eq(itemPeople.type, personType),
+    ];
+
+    if (userExclusion) {
+      seriesConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      seriesConditions.push(itemLibraryExclusion);
+    }
+
+    const seriesStats = await db
+      .select({
+        personId: people.id,
+        personName: people.name,
+        primaryImageTag: people.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.seriesId).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(itemPeople, eq(items.seriesId, itemPeople.itemId))
+      .innerJoin(
+        people,
+        and(
+          eq(itemPeople.personId, people.id),
+          eq(itemPeople.serverId, people.serverId),
+        ),
+      )
+      .where(and(...seriesConditions))
+      .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
+      .orderBy(desc(count(sessions.id)))
+      .limit(limit);
+
+    for (const stat of seriesStats) {
+      if (mediaType === "all") {
+        const existing = results.find((r) => r.id === stat.personId);
+        if (existing) {
+          existing.totalWatchTime += Number(stat.totalWatchTime ?? 0);
+          existing.totalPlayCount += Number(stat.totalPlayCount);
+          existing.itemCount += Number(stat.itemCount);
+        } else {
+          results.push({
+            id: stat.personId,
+            name: stat.personName,
+            primaryImageTag: stat.primaryImageTag,
+            type: personType,
+            totalWatchTime: Number(stat.totalWatchTime ?? 0),
+            totalPlayCount: Number(stat.totalPlayCount),
+            itemCount: Number(stat.itemCount),
+          });
+        }
+      } else {
+        results.push({
+          id: stat.personId,
+          name: stat.personName,
+          primaryImageTag: stat.primaryImageTag,
+          type: personType,
+          totalWatchTime: Number(stat.totalWatchTime ?? 0),
+          totalPlayCount: Number(stat.totalPlayCount),
+          itemCount: Number(stat.itemCount),
+        });
+      }
+    }
+  }
+
+  // Sort by play count and limit
+  results.sort((a, b) => b.totalPlayCount - a.totalPlayCount);
+  return results.slice(0, limit);
+}
+
+/**
+ * Get top director + actor combinations by watch time.
+ * Finds items where both a director and actor are credited, then aggregates.
+ */
+export async function getTopDirectorActorCombinations(
+  serverId: string | number,
+  mediaType: MediaTypeFilter,
+  limit = 15,
+): Promise<DirectorActorCombination[]> {
+  "use cache";
+  const serverIdNum = Number(serverId);
+  cacheLife("hours");
+  cacheTag(`people-combinations-${serverIdNum}-${mediaType}`);
+
+  const { userExclusion, itemLibraryExclusion } =
+    await getStatisticsExclusions(serverId);
+
+  // Create aliases for the self-join
+  const directors = db
+    .select({
+      itemId: itemPeople.itemId,
+      personId: itemPeople.personId,
+    })
+    .from(itemPeople)
+    .where(
+      and(
+        eq(itemPeople.serverId, serverIdNum),
+        eq(itemPeople.type, "Director"),
+      ),
+    )
+    .as("directors");
+
+  const actors = db
+    .select({
+      itemId: itemPeople.itemId,
+      personId: itemPeople.personId,
+    })
+    .from(itemPeople)
+    .where(
+      and(eq(itemPeople.serverId, serverIdNum), eq(itemPeople.type, "Actor")),
+    )
+    .as("actors");
+
+  const directorPeople = db
+    .select({
+      id: people.id,
+      name: people.name,
+      primaryImageTag: people.primaryImageTag,
+      serverId: people.serverId,
+    })
+    .from(people)
+    .where(eq(people.serverId, serverIdNum))
+    .as("directorPeople");
+
+  const actorPeople = db
+    .select({
+      id: people.id,
+      name: people.name,
+      primaryImageTag: people.primaryImageTag,
+      serverId: people.serverId,
+    })
+    .from(people)
+    .where(eq(people.serverId, serverIdNum))
+    .as("actorPeople");
+
+  const results: DirectorActorCombination[] = [];
+
+  // Query for Movies
+  if (mediaType === "all" || mediaType === "Movie") {
+    const movieConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Movie"),
+    ];
+
+    if (userExclusion) {
+      movieConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      movieConditions.push(itemLibraryExclusion);
+    }
+
+    const movieCombos = await db
+      .select({
+        directorId: directors.personId,
+        directorName: directorPeople.name,
+        directorImageTag: directorPeople.primaryImageTag,
+        actorId: actors.personId,
+        actorName: actorPeople.name,
+        actorImageTag: actorPeople.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.id).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(directors, eq(items.id, directors.itemId))
+      .innerJoin(actors, eq(items.id, actors.itemId))
+      .innerJoin(directorPeople, eq(directors.personId, directorPeople.id))
+      .innerJoin(actorPeople, eq(actors.personId, actorPeople.id))
+      .where(and(...movieConditions))
+      .groupBy(
+        directors.personId,
+        directorPeople.name,
+        directorPeople.primaryImageTag,
+        actors.personId,
+        actorPeople.name,
+        actorPeople.primaryImageTag,
+      )
+      .orderBy(desc(sum(sessions.playDuration)))
+      .limit(limit);
+
+    for (const combo of movieCombos) {
+      results.push({
+        directorId: combo.directorId,
+        directorName: combo.directorName,
+        directorImageTag: combo.directorImageTag,
+        actorId: combo.actorId,
+        actorName: combo.actorName,
+        actorImageTag: combo.actorImageTag,
+        totalWatchTime: Number(combo.totalWatchTime ?? 0),
+        totalPlayCount: Number(combo.totalPlayCount),
+        itemCount: Number(combo.itemCount),
+      });
+    }
+  }
+
+  // Query for Series
+  if (mediaType === "all" || mediaType === "Series") {
+    const seriesConditions: SQL[] = [
+      eq(sessions.serverId, serverIdNum),
+      isNotNull(sessions.itemId),
+      eq(items.type, "Episode"),
+      isNotNull(items.seriesId),
+    ];
+
+    if (userExclusion) {
+      seriesConditions.push(userExclusion);
+    }
+    if (itemLibraryExclusion) {
+      seriesConditions.push(itemLibraryExclusion);
+    }
+
+    // For series, join on seriesId
+    const seriesDirectors = db
+      .select({
+        itemId: itemPeople.itemId,
+        personId: itemPeople.personId,
+      })
+      .from(itemPeople)
+      .where(
+        and(
+          eq(itemPeople.serverId, serverIdNum),
+          eq(itemPeople.type, "Director"),
+        ),
+      )
+      .as("seriesDirectors");
+
+    const seriesActors = db
+      .select({
+        itemId: itemPeople.itemId,
+        personId: itemPeople.personId,
+      })
+      .from(itemPeople)
+      .where(
+        and(eq(itemPeople.serverId, serverIdNum), eq(itemPeople.type, "Actor")),
+      )
+      .as("seriesActors");
+
+    const seriesCombos = await db
+      .select({
+        directorId: seriesDirectors.personId,
+        directorName: directorPeople.name,
+        directorImageTag: directorPeople.primaryImageTag,
+        actorId: seriesActors.personId,
+        actorName: actorPeople.name,
+        actorImageTag: actorPeople.primaryImageTag,
+        totalWatchTime: sum(sessions.playDuration).as("totalWatchTime"),
+        totalPlayCount: count(sessions.id).as("totalPlayCount"),
+        itemCount: countDistinct(items.seriesId).as("itemCount"),
+      })
+      .from(sessions)
+      .innerJoin(items, eq(sessions.itemId, items.id))
+      .innerJoin(seriesDirectors, eq(items.seriesId, seriesDirectors.itemId))
+      .innerJoin(seriesActors, eq(items.seriesId, seriesActors.itemId))
+      .innerJoin(
+        directorPeople,
+        eq(seriesDirectors.personId, directorPeople.id),
+      )
+      .innerJoin(actorPeople, eq(seriesActors.personId, actorPeople.id))
+      .where(and(...seriesConditions))
+      .groupBy(
+        seriesDirectors.personId,
+        directorPeople.name,
+        directorPeople.primaryImageTag,
+        seriesActors.personId,
+        actorPeople.name,
+        actorPeople.primaryImageTag,
+      )
+      .orderBy(desc(sum(sessions.playDuration)))
+      .limit(limit);
+
+    for (const combo of seriesCombos) {
+      if (mediaType === "all") {
+        // Merge with existing results
+        const existing = results.find(
+          (r) =>
+            r.directorId === combo.directorId && r.actorId === combo.actorId,
+        );
+        if (existing) {
+          existing.totalWatchTime += Number(combo.totalWatchTime ?? 0);
+          existing.totalPlayCount += Number(combo.totalPlayCount);
+          existing.itemCount += Number(combo.itemCount);
+        } else {
+          results.push({
+            directorId: combo.directorId,
+            directorName: combo.directorName,
+            directorImageTag: combo.directorImageTag,
+            actorId: combo.actorId,
+            actorName: combo.actorName,
+            actorImageTag: combo.actorImageTag,
+            totalWatchTime: Number(combo.totalWatchTime ?? 0),
+            totalPlayCount: Number(combo.totalPlayCount),
+            itemCount: Number(combo.itemCount),
+          });
+        }
+      } else {
+        results.push({
+          directorId: combo.directorId,
+          directorName: combo.directorName,
+          directorImageTag: combo.directorImageTag,
+          actorId: combo.actorId,
+          actorName: combo.actorName,
+          actorImageTag: combo.actorImageTag,
+          totalWatchTime: Number(combo.totalWatchTime ?? 0),
+          totalPlayCount: Number(combo.totalPlayCount),
+          itemCount: Number(combo.itemCount),
+        });
+      }
+    }
+  }
+
+  // Sort by watch time and limit
+  results.sort((a, b) => b.totalWatchTime - a.totalWatchTime);
+  return results.slice(0, limit);
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a new People dashboard page showing viewing statistics for actors and directors, including top individuals and popular director–actor pairings, filterable by media type.

New Features:
- Introduce database queries to aggregate watch time, play count, and title counts for actors and directors across movies and series, with support for media-type filtering and exclusions.
- Add a People statistics dashboard with sections for top actors and directors by watch time and play count, and a carousel of popular director–actor combinations.
- Expose a media-type tab control on the People page to filter statistics between all content, movies, and series.
- Add a People navigation entry to the dashboard sidebar to access the new statistics view.