### PR TITLE
fix(#347): useQueryParams should strip basePath from pathname

### DIFF
--- a/apps/nextjs-app/hooks/useQueryParams.tsx
+++ b/apps/nextjs-app/hooks/useQueryParams.tsx
@@ -1,4 +1,4 @@
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState, useTransition } from "react";
 
 /**


### PR DESCRIPTION
Fixes #347 

The issue is that `window.location.pathname` includes the NEXT_PUBLIC_BASE_PATH already, and router.replace() will pre-pend the basePath to the URI we give it. Resulting in double basePath and a broken route. Stripping the basePath from pathname fixes the issue.

[video](https://i.imgur.com/hhtXvsh.mp4)

## Summary by Sourcery

Bug Fixes:
- Prevent double basePath being added to routes when updating query parameters via useQueryParams.