### PR TITLE
feat: improved ollama embed support

### DIFF
--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -437,6 +437,7 @@ async function processOllamaItem(
     {
       model: config.model,
       input: text,
+      keep_alive: '5m', // Unloads the model after 5 minutes of inactivity
       ...(config.dimensions ? { dimensions: config.dimensions } : {}),
     },
     { headers, timeout: TIMEOUT_CONFIG.DEFAULT }

--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -438,7 +438,7 @@ async function processOllamaItem(
     { headers, timeout: TIMEOUT_CONFIG.DEFAULT }
   );
 
-  const rawEmbedding = response.data.embedding || response.data.embeddings;
+  const rawEmbedding = response.data.embeddings?.[0] || response.data.embedding;
   if (!rawEmbedding) {
     throw new Error("No embedding returned from Ollama");
   }

--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -433,8 +433,8 @@ async function processOllamaItem(
   }
 
   const response = await axios.post(
-    `${config.baseUrl}/api/embeddings`,
-    { model: config.model, prompt: text },
+    `${config.baseUrl}/api/embed`,
+    { model: config.model, input: text, dimensions: config.dimensions, },
     { headers, timeout: TIMEOUT_CONFIG.DEFAULT }
   );
 

--- a/apps/job-server/src/jobs/embedding-jobs.ts
+++ b/apps/job-server/src/jobs/embedding-jobs.ts
@@ -434,7 +434,11 @@ async function processOllamaItem(
 
   const response = await axios.post(
     `${config.baseUrl}/api/embed`,
-    { model: config.model, input: text, dimensions: config.dimensions, },
+    {
+      model: config.model,
+      input: text,
+      ...(config.dimensions ? { dimensions: config.dimensions } : {}),
+    },
     { headers, timeout: TIMEOUT_CONFIG.DEFAULT }
   );
 


### PR DESCRIPTION
The OpenAI compatible endpoint does not have a "dimension" parameter, so if you are using ollama you get the model default dimension size.

Ollama docs: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings

Closes https://github.com/fredrikburmester/streamystats/issues/133

## Summary by Sourcery

Update Ollama embedding job to use the new /api/embed endpoint and correctly handle model dimensions and response format.

New Features:
- Support configuring embedding dimensions when calling Ollama via the /api/embed endpoint.

Bug Fixes:
- Correctly parse the primary embedding array element from Ollama responses that return embeddings as a list.