### PR TITLE
fix: detect preset should exempt ollama (similar to anthropic)

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
@@ -118,7 +118,7 @@ type PresetKey = keyof typeof PROVIDER_PRESETS;
 
 // Detect preset from server config
 function detectPreset(server: ServerPublic): PresetKey {
-  // Ollama uses a non-standard API, so check provider first regardless of URL
+  // Not openai-compatible providers should be detected first regarless of url
   if (server.embeddingProvider === "ollama") {
     return "ollama";
   }

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx
@@ -118,6 +118,11 @@ type PresetKey = keyof typeof PROVIDER_PRESETS;
 
 // Detect preset from server config
 function detectPreset(server: ServerPublic): PresetKey {
+  // Ollama uses a non-standard API, so check provider first regardless of URL
+  if (server.embeddingProvider === "ollama") {
+    return "ollama";
+  }
+
   const baseUrl = server.embeddingBaseUrl || "";
   for (const [key, preset] of Object.entries(PROVIDER_PRESETS)) {
     if (key !== "custom" && baseUrl === preset.baseUrl) {

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
@@ -101,6 +101,7 @@ const PROVIDER_PRESETS = {
 type PresetKey = keyof typeof PROVIDER_PRESETS;
 
 function detectPreset(server: ServerPublic): PresetKey {
+  // Not openai-compatible providers should be detected first regarless of url
   if (server.chatProvider === "anthropic") {
     return "anthropic";
   }

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
@@ -101,14 +101,18 @@ const PROVIDER_PRESETS = {
 type PresetKey = keyof typeof PROVIDER_PRESETS;
 
 function detectPreset(server: ServerPublic): PresetKey {
+  if (server.chatProvider === "anthropic") {
+    return "anthropic";
+  }
+  if (server.chatProvider === "ollama") {
+    return "ollama";
+  }
+
   const baseUrl = server.chatBaseUrl || "";
   for (const [key, preset] of Object.entries(PROVIDER_PRESETS)) {
     if (key !== "custom" && baseUrl === preset.baseUrl) {
       return key as PresetKey;
     }
-  }
-  if (server.chatProvider === "anthropic") {
-    return "anthropic";
   }
   return baseUrl ? "custom" : "openai";
 }


### PR DESCRIPTION
Just a visual bug

## Summary by Sourcery

Adjust preset detection for chat and embeddings providers to correctly handle Ollama and Anthropic configurations.

Bug Fixes:
- Ensure chat preset detection prioritizes explicit Anthropic and Ollama providers over base URL matching to avoid incorrect preset selection.
- Ensure embeddings preset detection recognizes Ollama based on the provider field even when using a non-standard base URL.