### PR TITLE
feat: add Bangladesh Standard Time (Dhaka) to timezone options

### DIFF
--- a/apps/nextjs-app/lib/timezone-data.ts
+++ b/apps/nextjs-app/lib/timezone-data.ts
@@ -40,6 +40,7 @@ export const TIMEZONE_OPTIONS = [
   { value: "Asia/Seoul", label: "Korea Standard Time (Seoul)" },
   { value: "Asia/Dubai", label: "Gulf Standard Time (Dubai)" },
   { value: "Asia/Kolkata", label: "India Standard Time (Kolkata)" },
+  { value: "Asia/Dhaka", label: "Bangladesh Standard Time (Dhaka)" },
   { value: "Asia/Bangkok", label: "Indochina Time (Bangkok)" },
   { value: "Asia/Jakarta", label: "Western Indonesia Time (Jakarta)" },
   { value: "Asia/Manila", label: "Philippine Time (Manila)" },


### PR DESCRIPTION
there's not much to say it's pretty simple, it closes #382

## Summary by Sourcery

New Features:
- Introduce Bangladesh Standard Time (Asia/Dhaka) as a selectable timezone option in the app.