### PR TITLE
fix: Support Voyage AI embeddings and fix Anthropic chat API endpoint

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx
@@ -49,7 +49,7 @@ const PROVIDER_PRESETS = {
   },
   anthropic: {
     name: "Anthropic",
-    baseUrl: "https://api.anthropic.com",
+    baseUrl: "https://api.anthropic.com/v1",
     defaultModel: "claude-3-5-sonnet-latest",
     requiresApiKey: true,
     provider: "anthropic" as ChatProvider,

--- a/apps/nextjs-app/lib/ai/providers.ts
+++ b/apps/nextjs-app/lib/ai/providers.ts
@@ -21,7 +21,7 @@ export const CHAT_PROVIDER_PRESETS = {
   },
   anthropic: {
     name: "Anthropic",
-    baseUrl: "https://api.anthropic.com",
+    baseUrl: "https://api.anthropic.com/v1",
     defaultModel: "claude-3-5-sonnet-latest",
     requiresApiKey: true,
     provider: "anthropic" as ChatProvider,

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -919,23 +919,27 @@ export const testChatConnection = async ({
 }): Promise<{ success: boolean; message: string }> => {
   try {
     if (config.provider === "anthropic") {
-      const response = await fetch(
-        `${config.baseUrl || "https://api.anthropic.com"}/v1/messages`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": config.apiKey || "",
-            "anthropic-version": "2023-06-01",
-          },
-          body: JSON.stringify({
-            model: config.model,
-            max_tokens: 10,
-            messages: [{ role: "user", content: "Hi" }],
-          }),
-          signal: AbortSignal.timeout(10000),
+      // Anthropic API endpoint is /v1/messages
+      // If baseUrl already includes /v1, use it as-is, otherwise append /v1
+      const baseUrl = config.baseUrl || "https://api.anthropic.com";
+      const apiUrl = baseUrl.endsWith("/v1")
+        ? `${baseUrl}/messages`
+        : `${baseUrl}/v1/messages`;
+      
+      const response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": config.apiKey || "",
+          "anthropic-version": "2023-06-01",
         },
-      );
+        body: JSON.stringify({
+          model: config.model,
+          max_tokens: 10,
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+        signal: AbortSignal.timeout(10000),
+      });
 
       if (!response.ok) {
         const error = await response.text();

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -912,6 +912,35 @@ export const clearChatConfig = async ({ serverId }: { serverId: number }) => {
   }
 };
 
+/**
+ * Normalizes Anthropic base URL and constructs the messages API endpoint.
+ * Handles edge cases like trailing slashes and existing /v1 paths.
+ * 
+ * @param baseUrl - The base URL (may include /v1, trailing slashes, etc.)
+ * @returns The full URL to the /v1/messages endpoint
+ */
+function getAnthropicMessagesUrl(baseUrl?: string): string {
+  const defaultBaseUrl = "https://api.anthropic.com";
+  const url = baseUrl || defaultBaseUrl;
+  
+  // Normalize: remove trailing slashes
+  const normalized = url.replace(/\/+$/, "");
+  
+  // Check if /v1 is already present (with or without trailing slash)
+  // Handle cases like: "https://api.anthropic.com/v1" or "https://api.anthropic.com/v1/"
+  if (normalized.endsWith("/v1")) {
+    return `${normalized}/messages`;
+  }
+  
+  // Check if /v1/messages is already present (avoid double-appending)
+  if (normalized.endsWith("/v1/messages")) {
+    return normalized;
+  }
+  
+  // Otherwise, append /v1/messages
+  return `${normalized}/v1/messages`;
+}
+
 export const testChatConnection = async ({
   config,
 }: {
@@ -919,12 +948,7 @@ export const testChatConnection = async ({
 }): Promise<{ success: boolean; message: string }> => {
   try {
     if (config.provider === "anthropic") {
-      // Anthropic API endpoint is /v1/messages
-      // If baseUrl already includes /v1, use it as-is, otherwise append /v1
-      const baseUrl = config.baseUrl || "https://api.anthropic.com";
-      const apiUrl = baseUrl.endsWith("/v1")
-        ? `${baseUrl}/messages`
-        : `${baseUrl}/v1/messages`;
+      const apiUrl = getAnthropicMessagesUrl(config.baseUrl);
       
       const response = await fetch(apiUrl, {
         method: "POST",


### PR DESCRIPTION
## Summary

This PR fixes AI chat and embedding issues and adds embedding resilience and AI settings UX improvements.

---

### 1. Voyage AI Embeddings Fix
- **Problem:** Voyage AI API requires `output_dimension`, but Streamystats was sending `dimensions`.
- **Solution:**
  - Use provider-aware detection (explicit provider flag or baseUrl) and send `output_dimension` via direct HTTP for Voyage AI.
  - Tighten unsupported-dimensions error detection (provider-aware, require dimension + param keywords for 400s; short-message heuristic only for Voyage AI).

### 2. Anthropic Chat API Endpoint Fix
- **Problem:** Anthropic Messages API is at `/v1/messages`; base URL was missing `/v1`.
- **Solution:**
  - Centralized `getAnthropicMessagesUrl()` helper: normalizes trailing slashes, handles `/v1` and `/v1/messages`, prevents double-appending.
  - Updated Anthropic preset to `https://api.anthropic.com/v1` and test connection to use the helper.

### 3. Code Review Follow-up (refactor)
- Voyage AI: prefer explicit provider flag, fallback to baseUrl.
- Error heuristic: no longer treat every 400 with short body as dimension error; require dimension + param keywords or Voyage-specific logic.
- Anthropic: single helper for messages URL used by test connection.

### 4. Embedding Job Resilience
- **Cron/scheduled runs:** Job payload from scheduler only has `serverId`; worker now loads embedding config from DB so background runs behave like manual start.
- **Rate limits:** On 429, wait 1 minute and retry same batch (up to 2×) instead of failing immediately.
- **Transient failures:** `MAX_CONSECUTIVE_BATCH_FAILURES` 5→10; 3s backoff after a batch failure to avoid aborting on brief API hiccups.

### 5. AI Settings Page (Settings → AI)
- **Remaining count:** Show “X items remaining to process for AI recommendations.”
- **Next batch timer:** When auto-embedding is on, show countdown to next run (every 15 min) and “Runs every 15 minutes when auto-generate is on.”
- **Start button:** Label “Start next batch” when there are remaining items, otherwise “Start embedding.”

---

## Files Changed
- `apps/job-server/src/jobs/embedding-jobs.ts`: Voyage AI handling, provider-aware detection, config-from-DB for cron, rate-limit backoff, resilience (consecutive failures + backoff).
- `apps/nextjs-app/lib/ai/providers.ts`: Anthropic base URL.
- `apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/chat/ChatAIManager.tsx`: Anthropic base URL.
- `apps/nextjs-app/lib/db/server.ts`: `getAnthropicMessagesUrl()`, test connection uses it.
- `apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/EmbeddingsManager.tsx`: Remaining count, next-batch countdown, “Start next batch” button label.

## Testing
- ✅ Voyage AI embeddings with `output_dimension`; stricter error detection.
- ✅ Anthropic chat with correct `/v1/messages` URL and edge cases (trailing slash, existing `/v1`).
- ✅ Scheduled embedding runs use DB config and complete; rate-limit backoff and failure backoff reduce aborted jobs.
- ✅ AI settings: remaining count, timer when auto on, and “Start next batch” label.