### PR TITLE
feat: add "Title Count" aggregation option for people stats

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { Clock, Film, Library, Play, TrendingUp } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import type { PersonLibraryStats, PersonStats } from "@/lib/db/people-stats";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { PersonLibraryStats, PersonStats, PlayCountSortBy } from "@/lib/db/people-stats";
 import type { ServerPublic } from "@/lib/types";
 import { PersonCard } from "./PersonCard";
 
@@ -24,6 +27,7 @@ interface Props {
   server: ServerPublic;
   variant: "watchtime" | "playcount" | "library";
   emptyMessage: string;
+  playCountSort?: PlayCountSortBy;
 }
 
 export function PeopleSection({
@@ -34,8 +38,21 @@ export function PeopleSection({
   server,
   variant,
   emptyMessage,
+  playCountSort,
 }: Props) {
   const Icon = iconMap[iconType];
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleSortChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("playCountSort", value);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   if (!people || people.length === 0) {
     return (
@@ -54,13 +71,30 @@ export function PeopleSection({
   return (
     <div className="rounded-lg border bg-card">
       <div className="p-4 pb-3">
-        <h2 className="text-lg font-bold flex items-center gap-2">
-          <div className="p-1.5 rounded-lg bg-primary/10">
-            <Icon className="h-4 w-4 text-primary" />
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h2 className="text-lg font-bold flex items-center gap-2">
+              <div className="p-1.5 rounded-lg bg-primary/10">
+                <Icon className="h-4 w-4 text-primary" />
+              </div>
+              {title}
+            </h2>
+            <p className="text-xs text-muted-foreground mt-1">{description}</p>
           </div>
-          {title}
-        </h2>
-        <p className="text-xs text-muted-foreground mt-1">{description}</p>
+
+          {variant === "playcount" && playCountSort && (
+            <Tabs value={playCountSort} onValueChange={handleSortChange}>
+              <TabsList className="h-8">
+                <TabsTrigger value="titleCount" className="text-xs px-2 py-1">
+                  Title Count
+                </TabsTrigger>
+                <TabsTrigger value="playCount" className="text-xs px-2 py-1">
+                  Total Plays
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          )}
+        </div>
       </div>
 
       <ScrollArea dir="ltr" className="w-full py-1">
@@ -71,6 +105,7 @@ export function PeopleSection({
               person={person}
               server={server}
               variant={variant}
+              displayMode={variant === "playcount" ? playCountSort : undefined}
             />
           ))}
         </div>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleSection.tsx
@@ -5,7 +5,11 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { PersonLibraryStats, PersonStats, PlayCountSortBy } from "@/lib/db/people-stats";
+import type {
+  PersonLibraryStats,
+  PersonStats,
+  PlayCountSortBy,
+} from "@/lib/db/people-stats";
 import type { ServerPublic } from "@/lib/types";
 import { PersonCard } from "./PersonCard";
 

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
@@ -29,7 +29,13 @@ export async function PeopleStats({ server, mediaType, playCountSort }: Props) {
     getTopPeopleByPlayCount(server.id, "Actor", mediaType, 20, playCountSort),
     getTopPeopleByLibraryPresence(server.id, "Actor", mediaType, 20),
     getTopPeopleByWatchTime(server.id, "Director", mediaType, 20),
-    getTopPeopleByPlayCount(server.id, "Director", mediaType, 20, playCountSort),
+    getTopPeopleByPlayCount(
+      server.id,
+      "Director",
+      mediaType,
+      20,
+      playCountSort,
+    ),
     getTopPeopleByLibraryPresence(server.id, "Director", mediaType, 20),
     getTopDirectorActorCombinations(server.id, mediaType, 15),
   ]);

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PeopleStats.tsx
@@ -1,4 +1,4 @@
-import type { MediaTypeFilter } from "@/lib/db/people-stats";
+import type { MediaTypeFilter, PlayCountSortBy } from "@/lib/db/people-stats";
 import {
   getTopDirectorActorCombinations,
   getTopPeopleByLibraryPresence,
@@ -12,9 +12,10 @@ import { PeopleSection } from "./PeopleSection";
 interface Props {
   server: ServerPublic;
   mediaType: MediaTypeFilter;
+  playCountSort: PlayCountSortBy;
 }
 
-export async function PeopleStats({ server, mediaType }: Props) {
+export async function PeopleStats({ server, mediaType, playCountSort }: Props) {
   const [
     topActorsByWatchTime,
     topActorsByPlayCount,
@@ -25,10 +26,10 @@ export async function PeopleStats({ server, mediaType }: Props) {
     directorActorCombos,
   ] = await Promise.all([
     getTopPeopleByWatchTime(server.id, "Actor", mediaType, 20),
-    getTopPeopleByPlayCount(server.id, "Actor", mediaType, 20),
+    getTopPeopleByPlayCount(server.id, "Actor", mediaType, 20, playCountSort),
     getTopPeopleByLibraryPresence(server.id, "Actor", mediaType, 20),
     getTopPeopleByWatchTime(server.id, "Director", mediaType, 20),
-    getTopPeopleByPlayCount(server.id, "Director", mediaType, 20),
+    getTopPeopleByPlayCount(server.id, "Director", mediaType, 20, playCountSort),
     getTopPeopleByLibraryPresence(server.id, "Director", mediaType, 20),
     getTopDirectorActorCombinations(server.id, mediaType, 15),
   ]);
@@ -62,6 +63,7 @@ export async function PeopleStats({ server, mediaType }: Props) {
         people={topActorsByPlayCount}
         server={server}
         variant="playcount"
+        playCountSort={playCountSort}
         emptyMessage="No actor watch statistics yet."
       />
 
@@ -92,6 +94,7 @@ export async function PeopleStats({ server, mediaType }: Props) {
         people={topDirectorsByPlayCount}
         server={server}
         variant="playcount"
+        playCountSort={playCountSort}
         emptyMessage="No director watch statistics yet."
       />
 

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
@@ -4,7 +4,7 @@ import { User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import type { PersonLibraryStats, PersonStats } from "@/lib/db/people-stats";
+import type { PersonLibraryStats, PersonStats, PlayCountSortBy } from "@/lib/db/people-stats";
 import type { ServerPublic } from "@/lib/types";
 import { formatDuration } from "@/lib/utils";
 
@@ -12,6 +12,7 @@ interface Props {
   person: PersonStats | PersonLibraryStats;
   server: ServerPublic;
   variant: "watchtime" | "playcount" | "library";
+  displayMode?: PlayCountSortBy;
 }
 
 function isPersonStats(
@@ -20,7 +21,7 @@ function isPersonStats(
   return "totalWatchTime" in person;
 }
 
-export function PersonCard({ person, server, variant }: Props) {
+export function PersonCard({ person, server, variant, displayMode }: Props) {
   const [hasError, setHasError] = useState(false);
 
   const imageUrl = person.primaryImageTag
@@ -48,17 +49,38 @@ export function PersonCard({ person, server, variant }: Props) {
       return null;
     }
 
-    return (
-      <>
-        {variant === "watchtime" ? (
-          <p className="text-xs font-medium text-primary">
-            {formatDuration(person.totalWatchTime)}
-          </p>
-        ) : (
+    // For playcount variant, show stats based on displayMode
+    if (variant === "playcount") {
+      if (displayMode === "titleCount") {
+        return (
+          <>
+            <p className="text-xs font-medium text-primary">
+              {person.itemCount} {person.itemCount === 1 ? "title" : "titles"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {person.totalPlayCount.toLocaleString()} plays
+            </p>
+          </>
+        );
+      }
+      return (
+        <>
           <p className="text-xs font-medium text-primary">
             {person.totalPlayCount.toLocaleString()} plays
           </p>
-        )}
+          <p className="text-xs text-muted-foreground">
+            {person.itemCount} {person.itemCount === 1 ? "title" : "titles"}
+          </p>
+        </>
+      );
+    }
+
+    // watchtime variant
+    return (
+      <>
+        <p className="text-xs font-medium text-primary">
+          {formatDuration(person.totalWatchTime)}
+        </p>
         <p className="text-xs text-muted-foreground">
           {person.itemCount} {person.itemCount === 1 ? "title" : "titles"}
         </p>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/PersonCard.tsx
@@ -4,7 +4,11 @@ import { User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import type { PersonLibraryStats, PersonStats, PlayCountSortBy } from "@/lib/db/people-stats";
+import type {
+  PersonLibraryStats,
+  PersonStats,
+  PlayCountSortBy,
+} from "@/lib/db/people-stats";
 import type { ServerPublic } from "@/lib/types";
 import { formatDuration } from "@/lib/utils";
 

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/people/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { Container } from "@/components/Container";
 import { PageTitle } from "@/components/PageTitle";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { MediaTypeFilter } from "@/lib/db/people-stats";
+import type { MediaTypeFilter, PlayCountSortBy } from "@/lib/db/people-stats";
 import { getServer } from "@/lib/db/server";
 import { PeopleStats } from "./PeopleStats";
 import { PeopleTypeTabs } from "./PeopleTypeTabs";
@@ -13,10 +13,10 @@ export default async function PeoplePage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ mediaType?: string }>;
+  searchParams: Promise<{ mediaType?: string; playCountSort?: string }>;
 }) {
   const { id } = await params;
-  const { mediaType } = await searchParams;
+  const { mediaType, playCountSort } = await searchParams;
   const server = await getServer({ serverId: id });
 
   if (!server) {
@@ -26,6 +26,10 @@ export default async function PeoplePage({
   // Validate mediaType parameter
   const effectiveMediaType: MediaTypeFilter =
     mediaType === "Movie" || mediaType === "Series" ? mediaType : "all";
+
+  // Validate playCountSort parameter
+  const effectivePlayCountSort: PlayCountSortBy =
+    playCountSort === "playCount" ? "playCount" : "titleCount";
 
   return (
     <Container className="flex flex-col">
@@ -42,7 +46,11 @@ export default async function PeoplePage({
           </div>
         }
       >
-        <PeopleStats server={server} mediaType={effectiveMediaType} />
+        <PeopleStats
+          server={server}
+          mediaType={effectiveMediaType}
+          playCountSort={effectivePlayCountSort}
+        />
       </Suspense>
     </Container>
   );

--- a/apps/nextjs-app/lib/db/people-stats.ts
+++ b/apps/nextjs-app/lib/db/people-stats.ts
@@ -391,9 +391,9 @@ export async function getTopPeopleByPlayCount(
       .where(and(...movieConditions))
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
       .orderBy(
-        sortBy === "titleCount"
-          ? (desc(countDistinct(items.id)), desc(count(sessions.id)))
-          : desc(count(sessions.id)),
+        ...(sortBy === "titleCount"
+          ? [desc(countDistinct(items.id)), desc(count(sessions.id))]
+          : [desc(count(sessions.id))]),
       )
       .limit(limit);
 
@@ -449,9 +449,9 @@ export async function getTopPeopleByPlayCount(
       .where(and(...seriesConditions))
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
       .orderBy(
-        sortBy === "titleCount"
-          ? (desc(countDistinct(items.seriesId)), desc(count(sessions.id)))
-          : desc(count(sessions.id)),
+        ...(sortBy === "titleCount"
+          ? [desc(countDistinct(items.seriesId)), desc(count(sessions.id))]
+          : [desc(count(sessions.id))]),
       )
       .limit(limit);
 

--- a/apps/nextjs-app/lib/db/people-stats.ts
+++ b/apps/nextjs-app/lib/db/people-stats.ts
@@ -332,13 +332,16 @@ export async function getTopPeopleByWatchTime(
 }
 
 /**
- * Get top people (actors or directors) by play count.
+ * Get top people (actors or directors) by play count or title count.
  */
+export type PlayCountSortBy = "playCount" | "titleCount";
+
 export async function getTopPeopleByPlayCount(
   serverId: string | number,
   personType: "Actor" | "Director",
   mediaType: MediaTypeFilter,
   limit = 20,
+  sortBy: PlayCountSortBy = "titleCount",
 ): Promise<PersonStats[]> {
   "use cache";
   cacheLife("hours");
@@ -387,7 +390,11 @@ export async function getTopPeopleByPlayCount(
       )
       .where(and(...movieConditions))
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
-      .orderBy(desc(count(sessions.id)))
+      .orderBy(
+        sortBy === "titleCount"
+          ? desc(countDistinct(items.id))
+          : desc(count(sessions.id)),
+      )
       .limit(limit);
 
     for (const stat of movieStats) {
@@ -441,7 +448,11 @@ export async function getTopPeopleByPlayCount(
       )
       .where(and(...seriesConditions))
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
-      .orderBy(desc(count(sessions.id)))
+      .orderBy(
+        sortBy === "titleCount"
+          ? desc(countDistinct(items.seriesId))
+          : desc(count(sessions.id)),
+      )
       .limit(limit);
 
     for (const stat of seriesStats) {
@@ -476,8 +487,12 @@ export async function getTopPeopleByPlayCount(
     }
   }
 
-  // Sort by play count and limit
-  results.sort((a, b) => b.totalPlayCount - a.totalPlayCount);
+  // Sort by the selected field and limit
+  if (sortBy === "titleCount") {
+    results.sort((a, b) => b.itemCount - a.itemCount);
+  } else {
+    results.sort((a, b) => b.totalPlayCount - a.totalPlayCount);
+  }
   return results.slice(0, limit);
 }
 

--- a/apps/nextjs-app/lib/db/people-stats.ts
+++ b/apps/nextjs-app/lib/db/people-stats.ts
@@ -392,7 +392,7 @@ export async function getTopPeopleByPlayCount(
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
       .orderBy(
         sortBy === "titleCount"
-          ? desc(countDistinct(items.id))
+          ? (desc(countDistinct(items.id)), desc(count(sessions.id)))
           : desc(count(sessions.id)),
       )
       .limit(limit);
@@ -450,7 +450,7 @@ export async function getTopPeopleByPlayCount(
       .groupBy(people.id, people.name, people.primaryImageTag, people.serverId)
       .orderBy(
         sortBy === "titleCount"
-          ? desc(countDistinct(items.seriesId))
+          ? (desc(countDistinct(items.seriesId)), desc(count(sessions.id)))
           : desc(count(sessions.id)),
       )
       .limit(limit);


### PR DESCRIPTION
### Summary
Introduces a toggle to calculate actor/person appearances based on unique titles rather than total episode count.

### The Problem
Currently, play counts for people are calculated by summing every individual episode or media entry. While accurate, this often "distorts" the statistics for users who watch long-running series.

Example: Watching all 10 seasons of Friends results in Lisa Kudrow having ~236 appearances. This makes it appear as though she is the user's most-watched person by a landslide, even if the user has watched 50 different movies featuring a different actor.

### Some before after results:

<img width="2085" height="657" alt="image" src="https://github.com/user-attachments/assets/6775f96e-f44b-4d3c-a80e-a86f36607256" />

<img width="2078" height="648" alt="image" src="https://github.com/user-attachments/assets/d5e2321e-2c44-4a07-a01d-bd0c6bf833af" />

## Summary by Sourcery

Add a configurable sort mode for people play count statistics based on either unique titles or total plays and surface it in the people dashboard UI.

New Features:
- Introduce a Title Count vs Total Plays toggle for people play count sections in the dashboard.
- Support server-side aggregation of people statistics by either unique title count or total play count via a new PlayCountSortBy option.

Enhancements:
- Display both title count and total plays per person in play count cards, ordered according to the selected display mode.