### PR TITLE
fix: dynamically compute Lunar New Year zodiac animal

### DIFF
--- a/apps/nextjs-app/lib/holidays.ts
+++ b/apps/nextjs-app/lib/holidays.ts
@@ -346,7 +346,9 @@ export const HOLIDAYS: Holiday[] = [
     id: "lunar-new-year",
     name: "Lunar New Year",
     icon: "Moon",
-    description: `Celebrate the Year of the ${getChineseZodiacAnimal(new Date().getFullYear())}`,
+    get description() {
+      return `Celebrate the Year of the ${getChineseZodiacAnimal(new Date().getFullYear())}`;
+    },
     dateRanges: [{ startMonth: 1, startDay: 20, endMonth: 2, endDay: 15 }],
     keywords: [
       "chinese new year",


### PR DESCRIPTION
Closes #396

Compute zodiac animal from current year instead of hardcoding "Year of the Dragon".

## Summary by Sourcery

Compute the Lunar New Year holiday description’s zodiac animal dynamically based on the current year instead of hardcoding a specific animal.

New Features:
- Introduce a helper to derive the Chinese zodiac animal from a given year.

Bug Fixes:
- Update the Lunar New Year description to use the correct zodiac animal for the current year instead of always referring to the Dragon.

Enhancements:
- Adjust Lunar New Year keywords to be less tightly coupled to a specific zodiac animal.