### PR TITLE
feat: add Asia/Karachi timezone option

### DIFF
--- a/apps/nextjs-app/lib/timezone-data.ts
+++ b/apps/nextjs-app/lib/timezone-data.ts
@@ -49,6 +49,7 @@ export const TIMEZONE_OPTIONS = [
   { value: "Asia/Ho_Chi_Minh", label: "Indochina Time (Ho Chi Minh)" },
   { value: "Asia/Jerusalem", label: "Israel Time (Jerusalem)" },
   { value: "Asia/Riyadh", label: "Arabia Standard Time (Riyadh)" },
+  { value: "Asia/Karachi", label: "Pakistan Standard Time (Karachi)" },
   // Australia & Oceania
   { value: "Australia/Sydney", label: "Australian Eastern Time (Sydney)" },
   {


### PR DESCRIPTION
Closes #404

Add Pakistan Standard Time (Karachi) to timezone options.

## Summary by Sourcery

New Features:
- Introduce Asia/Karachi (Pakistan Standard Time) as a selectable timezone option in the UI.