### PR TITLE
fix: hide last played user from non-admin users on library page

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/LibraryStatisticsCards.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/LibraryStatisticsCards.tsx
@@ -228,7 +228,11 @@ const StatItem: React.FC<{
   </div>
 );
 
-export const LibraryStatisticsCards: React.FC<Props> = ({ data, serverId, isAdmin }) => {
+export const LibraryStatisticsCards: React.FC<Props> = ({
+  data,
+  serverId,
+  isAdmin,
+}) => {
   if (data.length === 0) {
     return (
       <div className="text-center py-8 text-muted-foreground">

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/page.tsx
@@ -64,7 +64,11 @@ export default async function DashboardPage({
         title="Library"
         subtitle="Search for any movie or episode on your server."
       />
-      <LibraryStatisticsCards data={perLibraryStats} serverId={server.id} isAdmin={isAdmin} />
+      <LibraryStatisticsCards
+        data={perLibraryStats}
+        serverId={server.id}
+        isAdmin={isAdmin}
+      />
       <Suspense
         fallback={
           <div className="">


### PR DESCRIPTION
Closes #409

Only show "last played by" user info to admins on library statistics cards.

## Summary by Sourcery

Restrict display of library statistics metadata to user role and pass admin status through the library page to statistics cards.

Bug Fixes:
- Hide the "last played by" user information on library statistics cards for non-admin users by gating it on admin status.

Enhancements:
- Propagate an isAdmin flag from the library page to library statistics cards to enable role-based visibility of library details.