### PR TITLE
fix: allow server creation without session auth

### DIFF
--- a/apps/nextjs-app/lib/server.ts
+++ b/apps/nextjs-app/lib/server.ts
@@ -2,7 +2,6 @@
 
 import type { Server } from "@streamystats/database";
 import { z } from "zod/v4";
-import { getSession } from "@/lib/session";
 import type { ServerPublic } from "@/lib/types";
 
 const createServerSchema = z.object({
@@ -47,11 +46,6 @@ interface CreateServerErrorResponse {
 export async function createServer(
   serverData: CreateServerRequest,
 ): Promise<CreateServerSuccessResponse | CreateServerErrorResponse> {
-  const session = await getSession();
-  if (!session) {
-    return { success: false, details: "Authentication required" };
-  }
-
   const parsed = createServerSchema.safeParse(serverData);
   if (!parsed.success) {
     return { success: false, details: "Invalid input" };

--- a/apps/nextjs-app/proxy.ts
+++ b/apps/nextjs-app/proxy.ts
@@ -113,7 +113,7 @@ const ADMIN_ONLY_SUB_PATHS: Record<string, string[]> = {
   dashboard: ["security"],
 };
 const ADMIN_ONLY_USER_SUB_PATHS = ["security"];
-const PUBLIC_PATHS = ["login", "reconnect"];
+const PUBLIC_PATHS = ["login", "reconnect", "setup"];
 
 const BASE_PATH_REGEX = basePath.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
 


### PR DESCRIPTION
## Summary

Fixes #428. The security hardening in #425 and #427 added a session check to `createServer()` and left `/setup` out of the public paths list in the proxy. This broke onboarding since no session exists yet during initial setup, and also prevented adding additional servers without being logged in.

- Remove session auth check from `createServer()` — the job-server already validates the Jellyfin API key against the actual server
- Add `setup` to `PUBLIC_PATHS` in the proxy so the page is accessible without a session

## Summary by Sourcery

Allow server creation and setup access without requiring an existing session.

Bug Fixes:
- Remove the session authentication requirement from server creation to restore onboarding and server addition flows.
- Expose the setup route as a public path in the proxy so it is accessible without an authenticated session.