### PR TITLE
Fix: duplicate key error during media source sync

### DIFF
--- a/apps/job-server/src/jellyfin/sync/items.ts
+++ b/apps/job-server/src/jellyfin/sync/items.ts
@@ -1468,7 +1468,7 @@ async function syncMediaSourcesBatch(
     return;
   }
 
-  const allMediaSourceRecords: NewMediaSource[] = [];
+  const mediaSourceMap = new Map<string, NewMediaSource>();
   const allItemIds = jellyfinItems.map((item) => item.Id);
 
   for (const jellyfinItem of jellyfinItems) {
@@ -1480,8 +1480,9 @@ async function syncMediaSourcesBatch(
 
     for (let index = 0; index < jellyfinMediaSources.length; index++) {
       const ms = jellyfinMediaSources[index] as Record<string, unknown>;
-      allMediaSourceRecords.push({
-        id: (ms.Id as string) || `${jellyfinItem.Id}-${index}`,
+      const id = (ms.Id as string) || `${jellyfinItem.Id}-${index}`;
+      mediaSourceMap.set(id, {
+        id,
         itemId: jellyfinItem.Id,
         serverId,
         size: typeof ms.Size === "number" ? ms.Size : null,
@@ -1494,6 +1495,8 @@ async function syncMediaSourcesBatch(
       });
     }
   }
+
+  const allMediaSourceRecords = Array.from(mediaSourceMap.values());
 
   try {
     // Insert media sources in batches of 500 to avoid query size limits


### PR DESCRIPTION
### Description:
 When the same item exists in multiple libraries, the sync fetches it multiple times. Since each copy shares the same media source ID, the batch insert crashes with a unique-constraint violation:
 ```
 [items-sync] Error syncing media sources batch: Failed query: insert into "media_sources" ("id", "item_id", "server_id", "size", "bitrate", "container", "name", "path", "is_remote", "runtime_ticks", "created_at", "updated_at") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, default, default), ($11, $12, $13, $14, $15, $16, $17, $18, $19, $20, default, default), ($21, $22, $23, $24, $25, $26, $27, $28, $29, $30, default, default), ($31, $32, $33, $34, $35, $36, $37, $38, $39, $40, default, default), ($41, $42, $43, $44, $45, $46, $47, $48, $49, $50, default, default), ($51, $52, $53, $54, $55, $56, $57, $58, $59, $60, default, default), ($61, $62, $63, $64, $65, $66, $67, $68, $69, $70, default, default)
[...]
on conflict ("id") do update set "size" = EXCLUDED.size, "bitrate" = EXCLUDED.bitrate, "container" = EXCLUDED.container, "name" = EXCLUDED.name, "path" = EXCLUDED.path, "is_remote" = EXCLUDED.is_remote, "runtime_ticks" = EXCLUDED.runtime_ticks, "updated_at" = NOW()
params: b5c01caa9109187687d2506420262d99,b5c01caa9109187687d2506420262d99,1,6317509936,8753567,mkv,Asteroid.City.2023.[EN].[EAC3.Atmos.5.1].WEBDL-2160p.[10bit.DV.HDR10x265]-Pahe,/media/<REDACTED>/movies/Asteroid City (2023) [imdbid-tt14230388]/Asteroid.City.2023.[EN].[EAC3.Atmos.5.1].WEBDL-2160p.[10bit.DV.HDR10x265]-Pahe.mkv,false,63289280000,4bbf4fc493135c83d53bd2c3aa2a40d4,4bbf4fc493135c83d53bd2c3aa2a40d4,1,11734834033,11332565,mkv,The.Help.2011.[EN].[EAC3.5.1].Bluray-1080p.[8bit.x264]-hallowed,/media/<REDACTED>/movies/The Help (2011) [imdbid-tt1454029]/The.Help.2011.[EN].[EAC3.5.1].Bluray-1080p.[8bit.x264]-hallowed.mkv,false,87798080000,
[...]
f5e01422e0d35c45023a3c04e68d3e0f,f5e01422e0d35c45023a3c04e68d3e0f,1,3186344761,14321472,mkv,How.to.Sell.Drugs.Online.Fast.2019.S01E01.Nerd.Today.Boss.Tomorrow.[DE+EN].[EAC3.5.1].WEBDL-2160p.[10bit.h265]-ABBiE,/media/<REDACTED>/series/How to Sell Drugs Online (Fast) (2019) [imdbid-tt9184994]/Season 01/How.to.Sell.Drugs.Online.Fast.2019.S01E01.Nerd.Today.Boss.Tomorrow.[DE+EN].[EAC3.5.1].WEBDL-2160p.[10bit.h265]-ABBiE.mkv,false,19545920000,3368226a2bc2b7f0a9d9e71bc4f5cb6a,3368226a2bc2b7f0a9d9e71bc4f5cb6a,1,5250394812,21394580,mkv,How.to.Sell.Drugs.Online.Fast.2019.S04E02.That.Doesnt.Happen.on.My.Machine.[DE+EN].[EAC3.Atmos.5.1].WEBDL-2160p.[10bit.HDR10.h265]-HHWEB,/media/<REDACTED>/series/How to Sell Drugs Online (Fast) (2019) [imdbid-tt9184994]/Season 04/How.to.Sell.Drugs.Online.Fast.2019.S04E02.That.Doesnt.Happen.on.My.Machine.[DE+EN].[EAC3.Atmos.5.1].WEBDL-2160p.[10bit.HDR10.h265]-HHWEB.mkv,false,21015680000,2957cac672cd65c7070bc50f8eec4d5c,2957cac672cd65c7070bc50f8eec4d5c,1,5207243300,21050858,mkv,How.to.Sell.Drugs.Online.Fast.2019.S04E01.That.Cant.Happen.[DE+EN].[EAC3.Atmos.5.1].WEBDL-2160p.[10bit.HDR10.h265]-HHWEB,/media/<REDACTED>/series/How to Sell Drugs On[jellyfin-sync] serverId=1 syncType=recent_items action=start
[jellyfin-sync] server=jellyfin.DOMAIN.TLD serverId=1 syncType=recent_items action=loadedServer url=https://jellyfin.DOMAIN.TLD
```
This fix now deduplicates by ID before inserting.
 
 ### Fixes:
[#408 ([BUG] [items-sync] Error syncing media sources batch: Failed query: insert into "media_sources")](https://github.com/fredrikburmester/streamystats/issues/408)

*AI disclosure:
Developed with assistance from Claude Code (Opus 4.6). The AI helped me identify the root cause and proposed possible fixes.*

## Summary by Sourcery

Bug Fixes:
- Resolve duplicate key errors in media source batch insert by aggregating media sources in a map keyed by media source ID before insertion.