### PR TITLE
fix: migrate Jellyfin API calls to MediaBrowser auth header

### DIFF
--- a/apps/job-server/src/jellyfin/client.ts
+++ b/apps/job-server/src/jellyfin/client.ts
@@ -4,6 +4,7 @@ import pRetry from "p-retry";
 import { Server } from "@streamystats/database";
 import { JellyfinSession } from "./types";
 import { getInternalUrl } from "../utils/server-url";
+import { STREAMYSTATS_VERSION } from "../jobs/server-jobs";
 
 export interface JellyfinConfig {
   baseURL: string;
@@ -369,7 +370,7 @@ export class JellyfinClient {
       baseURL: this.config.baseURL,
       timeout: this.config.timeout,
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${this.config.apiKey}"`,
+        "Authorization": `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${this.config.apiKey}"`,
         "Content-Type": "application/json",
       },
     });

--- a/apps/job-server/src/jellyfin/client.ts
+++ b/apps/job-server/src/jellyfin/client.ts
@@ -369,7 +369,7 @@ export class JellyfinClient {
       baseURL: this.config.baseURL,
       timeout: this.config.timeout,
       headers: {
-        "X-Emby-Token": this.config.apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${this.config.apiKey}"`,
         "Content-Type": "application/json",
       },
     });

--- a/apps/job-server/src/jobs/server-jobs.ts
+++ b/apps/job-server/src/jobs/server-jobs.ts
@@ -21,7 +21,7 @@ export async function addServerJob(job: PgBossJob<AddServerJobData>) {
     // Test server connection
     const response = await axios.get(`${serverUrl}/System/Info`, {
       headers: {
-        "X-Emby-Token": apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
     });
@@ -102,7 +102,7 @@ export async function backfillJellyfinIdsJob(job: PgBossJob<Record<string, never
       try {
         const response = await axios.get(`${getInternalUrl(server)}/System/Info`, {
           headers: {
-            "X-Emby-Token": server.apiKey,
+            "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
             "Content-Type": "application/json",
           },
           timeout: 10000,

--- a/apps/job-server/src/jobs/server-jobs.ts
+++ b/apps/job-server/src/jobs/server-jobs.ts
@@ -9,6 +9,7 @@ import type { PgBossJob, AddServerJobData } from "../types/job-status";
 export const BACKFILL_JOB_NAMES = {
   BACKFILL_JELLYFIN_IDS: "backfill-jellyfin-ids",
 } as const;
+export const STREAMYSTATS_VERSION = "2.16.0"; // x-release-please-version
 
 // Job: Add a new media server
 export async function addServerJob(job: PgBossJob<AddServerJobData>) {
@@ -21,7 +22,7 @@ export async function addServerJob(job: PgBossJob<AddServerJobData>) {
     // Test server connection
     const response = await axios.get(`${serverUrl}/System/Info`, {
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        "Authorization": `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
     });
@@ -102,7 +103,7 @@ export async function backfillJellyfinIdsJob(job: PgBossJob<Record<string, never
       try {
         const response = await axios.get(`${getInternalUrl(server)}/System/Info`, {
           headers: {
-            "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
+            "Authorization": `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${server.apiKey}"`,
             "Content-Type": "application/json",
           },
           timeout: 10000,

--- a/apps/job-server/src/routes/jobs/servers.ts
+++ b/apps/job-server/src/routes/jobs/servers.ts
@@ -201,7 +201,7 @@ app.post("/create-server", async (c) => {
     try {
       const testResponse = await fetch(`${url}/System/Info`, {
         headers: {
-          "X-Emby-Token": apiKey,
+          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
       });
@@ -378,4 +378,3 @@ app.post("/backfill-jellyfin-ids", async (c) => {
 });
 
 export default app;
-

--- a/apps/job-server/src/routes/jobs/servers.ts
+++ b/apps/job-server/src/routes/jobs/servers.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { getJobQueue, JobTypes } from "../../jobs/queue";
 import { JELLYFIN_JOB_NAMES } from "../../jellyfin/workers";
-import { BACKFILL_JOB_NAMES } from "../../jobs/server-jobs";
+import { BACKFILL_JOB_NAMES, STREAMYSTATS_VERSION } from "../../jobs/server-jobs";
 import {
   db,
   servers,
@@ -201,7 +201,7 @@ app.post("/create-server", async (c) => {
     try {
       const testResponse = await fetch(`${url}/System/Info`, {
         headers: {
-          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+          "Authorization": `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
       });

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
@@ -31,7 +31,9 @@ async function getItemPlayedStatus(
     const response = await fetch(
       `${serverUrl}/Users/${userId}/Items/${itemId}`,
       {
-        headers: { "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"` },
+        headers: {
+          Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
+        },
         signal: AbortSignal.timeout(5000),
         next: { revalidate: 60 },
       },
@@ -100,10 +102,10 @@ export default async function ItemDetailsPage({
   const [cast, directors, writers] =
     itemDetails.item.type === "Movie" || itemDetails.item.type === "Series"
       ? await Promise.all([
-        getItemCast(itemId, server.id),
-        getItemDirectors(itemId, server.id),
-        getItemWriters(itemId, server.id),
-      ])
+          getItemCast(itemId, server.id),
+          getItemDirectors(itemId, server.id),
+          getItemWriters(itemId, server.id),
+        ])
       : [[], [], []];
 
   return (
@@ -126,14 +128,14 @@ export default async function ItemDetailsPage({
         />
         {(itemDetails.item.type === "Movie" ||
           itemDetails.item.type === "Series") && (
-            <CastSection
-              cast={cast}
-              directors={directors}
-              writers={writers}
-              server={server}
-              serverId={id}
-            />
-          )}
+          <CastSection
+            cast={cast}
+            directors={directors}
+            writers={writers}
+            server={server}
+            serverId={id}
+          />
+        )}
         {itemDetails.item.type === "Series" && seasons.length > 0 && (
           <SeasonsAndEpisodes seasons={seasons} serverId={id} server={server} />
         )}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
@@ -31,7 +31,7 @@ async function getItemPlayedStatus(
     const response = await fetch(
       `${serverUrl}/Users/${userId}/Items/${itemId}`,
       {
-        headers: { "X-Emby-Token": token },
+        headers: { "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"` },
         signal: AbortSignal.timeout(5000),
         next: { revalidate: 60 },
       },
@@ -100,10 +100,10 @@ export default async function ItemDetailsPage({
   const [cast, directors, writers] =
     itemDetails.item.type === "Movie" || itemDetails.item.type === "Series"
       ? await Promise.all([
-          getItemCast(itemId, server.id),
-          getItemDirectors(itemId, server.id),
-          getItemWriters(itemId, server.id),
-        ])
+        getItemCast(itemId, server.id),
+        getItemDirectors(itemId, server.id),
+        getItemWriters(itemId, server.id),
+      ])
       : [[], [], []];
 
   return (
@@ -126,14 +126,14 @@ export default async function ItemDetailsPage({
         />
         {(itemDetails.item.type === "Movie" ||
           itemDetails.item.type === "Series") && (
-          <CastSection
-            cast={cast}
-            directors={directors}
-            writers={writers}
-            server={server}
-            serverId={id}
-          />
-        )}
+            <CastSection
+              cast={cast}
+              directors={directors}
+              writers={writers}
+              server={server}
+              serverId={id}
+            />
+          )}
         {itemDetails.item.type === "Series" && seasons.length > 0 && (
           <SeasonsAndEpisodes seasons={seasons} serverId={id} server={server} />
         )}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
@@ -32,7 +32,7 @@ async function getItemPlayedStatus(
       `${serverUrl}/Users/${userId}/Items/${itemId}`,
       {
         headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
         },
         signal: AbortSignal.timeout(5000),
         next: { revalidate: 60 },

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/library/[itemId]/page.tsx
@@ -14,6 +14,7 @@ import {
   type RecommendationItem,
 } from "@/lib/db/similar-statistics";
 import { getMe, isUserAdmin } from "@/lib/db/users";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getToken } from "@/lib/token";
 import { CastSection } from "./CastSection";
 import { ItemHeader } from "./ItemHeader";
@@ -31,9 +32,7 @@ async function getItemPlayedStatus(
     const response = await fetch(
       `${serverUrl}/Users/${userId}/Items/${itemId}`,
       {
-        headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
-        },
+        headers: jellyfinHeaders(token),
         signal: AbortSignal.timeout(5000),
         next: { revalidate: 60 },
       },

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/actions.ts
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/actions.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod/v4";
 import { deleteServer as deleteServerFromDb } from "@/lib/db/server";
 import { isUserAdmin } from "@/lib/db/users";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 
 const deleteServerSchema = z.object({
   serverId: z.number().int().positive(),
@@ -132,10 +133,7 @@ export async function updateConnectionSettingsAction({
     try {
       const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
         method: "GET",
-        headers: {
-          "X-Emby-Token": effectiveApiKey,
-          "Content-Type": "application/json",
-        },
+        headers: jellyfinHeaders(effectiveApiKey),
         signal: AbortSignal.timeout(5000),
       });
 
@@ -167,10 +165,7 @@ export async function updateConnectionSettingsAction({
             `${normalizedInternalUrl}/System/Info`,
             {
               method: "GET",
-              headers: {
-                "X-Emby-Token": effectiveApiKey,
-                "Content-Type": "application/json",
-              },
+              headers: jellyfinHeaders(effectiveApiKey),
               signal: AbortSignal.timeout(5000),
             },
           );

--- a/apps/nextjs-app/app/api/Sessions/route.ts
+++ b/apps/nextjs-app/app/api/Sessions/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
     const response = await fetch(`${getInternalUrl(server)}/Sessions`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": server.apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
         "Content-Type": "application/json",
       },
     });
@@ -210,19 +210,19 @@ async function mapJellyfinSessionToActiveSession(
     playMethod: session.PlayState.PlayMethod || null,
     transcodingInfo: session.TranscodingInfo
       ? {
-          videoCodec: session.TranscodingInfo.VideoCodec,
-          audioCodec: session.TranscodingInfo.AudioCodec,
-          container: session.TranscodingInfo.Container,
-          isVideoDirect: session.TranscodingInfo.IsVideoDirect,
-          isAudioDirect: session.TranscodingInfo.IsAudioDirect,
-          bitrate: session.TranscodingInfo.Bitrate,
-          width: session.TranscodingInfo.Width,
-          height: session.TranscodingInfo.Height,
-          audioChannels: session.TranscodingInfo.AudioChannels,
-          hardwareAccelerationType:
-            session.TranscodingInfo.HardwareAccelerationType,
-          transcodeReasons: session.TranscodingInfo.TranscodeReasons,
-        }
+        videoCodec: session.TranscodingInfo.VideoCodec,
+        audioCodec: session.TranscodingInfo.AudioCodec,
+        container: session.TranscodingInfo.Container,
+        isVideoDirect: session.TranscodingInfo.IsVideoDirect,
+        isAudioDirect: session.TranscodingInfo.IsAudioDirect,
+        bitrate: session.TranscodingInfo.Bitrate,
+        width: session.TranscodingInfo.Width,
+        height: session.TranscodingInfo.Height,
+        audioChannels: session.TranscodingInfo.AudioChannels,
+        hardwareAccelerationType:
+          session.TranscodingInfo.HardwareAccelerationType,
+        transcodeReasons: session.TranscodingInfo.TranscodeReasons,
+      }
       : undefined,
     ipAddress: session.RemoteEndPoint || undefined,
   };

--- a/apps/nextjs-app/app/api/Sessions/route.ts
+++ b/apps/nextjs-app/app/api/Sessions/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
     const response = await fetch(`${getInternalUrl(server)}/Sessions`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
         "Content-Type": "application/json",
       },
     });
@@ -210,19 +210,19 @@ async function mapJellyfinSessionToActiveSession(
     playMethod: session.PlayState.PlayMethod || null,
     transcodingInfo: session.TranscodingInfo
       ? {
-        videoCodec: session.TranscodingInfo.VideoCodec,
-        audioCodec: session.TranscodingInfo.AudioCodec,
-        container: session.TranscodingInfo.Container,
-        isVideoDirect: session.TranscodingInfo.IsVideoDirect,
-        isAudioDirect: session.TranscodingInfo.IsAudioDirect,
-        bitrate: session.TranscodingInfo.Bitrate,
-        width: session.TranscodingInfo.Width,
-        height: session.TranscodingInfo.Height,
-        audioChannels: session.TranscodingInfo.AudioChannels,
-        hardwareAccelerationType:
-          session.TranscodingInfo.HardwareAccelerationType,
-        transcodeReasons: session.TranscodingInfo.TranscodeReasons,
-      }
+          videoCodec: session.TranscodingInfo.VideoCodec,
+          audioCodec: session.TranscodingInfo.AudioCodec,
+          container: session.TranscodingInfo.Container,
+          isVideoDirect: session.TranscodingInfo.IsVideoDirect,
+          isAudioDirect: session.TranscodingInfo.IsAudioDirect,
+          bitrate: session.TranscodingInfo.Bitrate,
+          width: session.TranscodingInfo.Width,
+          height: session.TranscodingInfo.Height,
+          audioChannels: session.TranscodingInfo.AudioChannels,
+          hardwareAccelerationType:
+            session.TranscodingInfo.HardwareAccelerationType,
+          transcodeReasons: session.TranscodingInfo.TranscodeReasons,
+        }
       : undefined,
     ipAddress: session.RemoteEndPoint || undefined,
   };

--- a/apps/nextjs-app/app/api/Sessions/route.ts
+++ b/apps/nextjs-app/app/api/Sessions/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
     const response = await fetch(`${getInternalUrl(server)}/Sessions`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${server.apiKey}"`,
         "Content-Type": "application/json",
       },
     });

--- a/apps/nextjs-app/app/api/Sessions/route.ts
+++ b/apps/nextjs-app/app/api/Sessions/route.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { requireSession } from "@/lib/api-auth";
 import type { ActiveSession } from "@/lib/db/active-sessions";
 import { getServerWithSecrets } from "@/lib/db/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getInternalUrl } from "@/lib/server-url";
 
 export async function GET(request: Request) {
@@ -46,10 +47,7 @@ export async function GET(request: Request) {
   try {
     const response = await fetch(`${getInternalUrl(server)}/Sessions`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${server.apiKey}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(server.apiKey),
     });
 
     // Pass through the actual status code from Jellyfin for better error handling on the client

--- a/apps/nextjs-app/app/api/check-connectivity/route.ts
+++ b/apps/nextjs-app/app/api/check-connectivity/route.ts
@@ -40,10 +40,9 @@ export async function GET() {
           {
             method: "GET",
             headers: {
-              "X-Emby-Token": server.apiKey,
+              Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
               "Content-Type": "application/json",
             },
-            // Short timeout to avoid hanging requests
             signal: AbortSignal.timeout(3000),
           },
         );

--- a/apps/nextjs-app/app/api/check-connectivity/route.ts
+++ b/apps/nextjs-app/app/api/check-connectivity/route.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { requireSession } from "@/lib/api-auth";
 import { getServersWithSecrets } from "@/lib/db/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getInternalUrl } from "@/lib/server-url";
 
 export async function GET() {
@@ -39,10 +40,7 @@ export async function GET() {
           `${getInternalUrl(server)}/System/Ping`,
           {
             method: "GET",
-            headers: {
-              Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
-              "Content-Type": "application/json",
-            },
+            headers: jellyfinHeaders(server.apiKey),
             signal: AbortSignal.timeout(3000),
           },
         );

--- a/apps/nextjs-app/app/api/export/[serverId]/route.ts
+++ b/apps/nextjs-app/app/api/export/[serverId]/route.ts
@@ -23,7 +23,7 @@ async function tryFetchJellyfinSystemInfo({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/export/[serverId]/route.ts
+++ b/apps/nextjs-app/app/api/export/[serverId]/route.ts
@@ -23,7 +23,7 @@ async function tryFetchJellyfinSystemInfo({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/export/[serverId]/route.ts
+++ b/apps/nextjs-app/app/api/export/[serverId]/route.ts
@@ -23,7 +23,7 @@ async function tryFetchJellyfinSystemInfo({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/export/[serverId]/route.ts
+++ b/apps/nextjs-app/app/api/export/[serverId]/route.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getServerWithSecrets } from "@/lib/db/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 
 type JellyfinSystemInfo = {
   Id?: string;
@@ -22,10 +23,7 @@ async function tryFetchJellyfinSystemInfo({
   try {
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(apiKey),
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) return null;

--- a/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
+++ b/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
@@ -41,7 +41,7 @@ export async function GET(
     const res = await fetch(jellyfinUrl, {
       method: "GET",
       headers: {
-        "X-Emby-Token": server.apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
       },
     });
 

--- a/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
+++ b/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
@@ -41,7 +41,7 @@ export async function GET(
     const res = await fetch(jellyfinUrl, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
       },
     });
 

--- a/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
+++ b/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
@@ -1,6 +1,7 @@
 import { db, servers } from "@streamystats/database";
 import { ilike } from "drizzle-orm";
 import type { NextRequest } from "next/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getInternalUrl } from "@/lib/server-url";
 
 async function getServerByName(name: string) {
@@ -41,7 +42,7 @@ export async function GET(
     const res = await fetch(jellyfinUrl, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${server.apiKey}"`,
+        Authorization: jellyfinHeaders(server.apiKey).Authorization,
       },
     });
 

--- a/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
+++ b/apps/nextjs-app/app/api/image-proxy/[itemId]/route.ts
@@ -41,7 +41,7 @@ export async function GET(
     const res = await fetch(jellyfinUrl, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${server.apiKey}"`,
       },
     });
 

--- a/apps/nextjs-app/app/api/import/route.ts
+++ b/apps/nextjs-app/app/api/import/route.ts
@@ -29,7 +29,7 @@ async function tryFetchJellyfinSystemId({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/import/route.ts
+++ b/apps/nextjs-app/app/api/import/route.ts
@@ -29,7 +29,7 @@ async function tryFetchJellyfinSystemId({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/import/route.ts
+++ b/apps/nextjs-app/app/api/import/route.ts
@@ -29,7 +29,7 @@ async function tryFetchJellyfinSystemId({
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/app/api/import/route.ts
+++ b/apps/nextjs-app/app/api/import/route.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { getServerWithSecrets } from "@/lib/db/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 
 type JellyfinSystemInfo = { Id?: string };
 
@@ -28,10 +29,7 @@ async function tryFetchJellyfinSystemId({
   try {
     const res = await fetch(`${normalizeUrl(url)}/System/Info`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(apiKey),
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) return null;

--- a/apps/nextjs-app/app/api/servers/route.ts
+++ b/apps/nextjs-app/app/api/servers/route.ts
@@ -37,7 +37,7 @@ async function validateJellyfinAdmin(
     const response = await fetch(`${url}/Users/Me`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": apiKey,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/app/api/servers/route.ts
+++ b/apps/nextjs-app/app/api/servers/route.ts
@@ -37,7 +37,7 @@ async function validateJellyfinAdmin(
     const response = await fetch(`${url}/Users/Me`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/app/api/servers/route.ts
+++ b/apps/nextjs-app/app/api/servers/route.ts
@@ -37,7 +37,7 @@ async function validateJellyfinAdmin(
     const response = await fetch(`${url}/Users/Me`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/app/api/servers/route.ts
+++ b/apps/nextjs-app/app/api/servers/route.ts
@@ -1,4 +1,5 @@
 import { getServers } from "@/lib/db/server";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { createServer } from "@/lib/server";
 
 export async function GET() {
@@ -36,10 +37,7 @@ async function validateJellyfinAdmin(
   try {
     const response = await fetch(`${url}/Users/Me`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(apiKey),
       signal: AbortSignal.timeout(10000),
     });
 

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -55,7 +55,7 @@ export async function validateJellyfinToken(
     const response = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),
@@ -155,7 +155,7 @@ export async function validateApiKey({
       const response = await fetch(`${getInternalUrl(server)}/System/Info`, {
         method: "GET",
         headers: {
-          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         // Short timeout to avoid hanging requests
@@ -245,13 +245,13 @@ export async function requireApiKey({
  */
 export async function requireSession(): Promise<
   | {
-    error: Response;
-    session: null;
-  }
+      error: Response;
+      session: null;
+    }
   | {
-    error: null;
-    session: SessionUser;
-  }
+      error: null;
+      session: SessionUser;
+    }
 > {
   const session = await getSession();
 
@@ -285,13 +285,13 @@ export async function requireSession(): Promise<
  */
 export async function requireAuth(request: NextRequest): Promise<
   | {
-    error: Response;
-    session: null;
-  }
+      error: Response;
+      session: null;
+    }
   | {
-    error: null;
-    session: SessionUser;
-  }
+      error: null;
+      session: SessionUser;
+    }
 > {
   // Try session cookie first (web app)
   const session = await getSession();
@@ -330,13 +330,13 @@ export async function requireAuth(request: NextRequest): Promise<
  */
 export async function requireAdmin(): Promise<
   | {
-    error: Response;
-    session: null;
-  }
+      error: Response;
+      session: null;
+    }
   | {
-    error: null;
-    session: SessionUser;
-  }
+      error: null;
+      session: SessionUser;
+    }
 > {
   const result = await requireSession();
 

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -6,6 +6,7 @@ import type { Server } from "@streamystats/database";
 import { db, servers, users } from "@streamystats/database";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
+import { jellyfinHeaders } from "./jellyfin-auth";
 import { getInternalUrl } from "./server-url";
 import { getSession, type SessionUser } from "./session";
 
@@ -54,10 +55,7 @@ export async function validateJellyfinToken(
   try {
     const response = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(token),
       signal: AbortSignal.timeout(5000),
     });
 
@@ -154,11 +152,7 @@ export async function validateApiKey({
     try {
       const response = await fetch(`${getInternalUrl(server)}/System/Info`, {
         method: "GET",
-        headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-          "Content-Type": "application/json",
-        },
-        // Short timeout to avoid hanging requests
+        headers: jellyfinHeaders(apiKey),
         signal: AbortSignal.timeout(5000),
       });
 

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -55,7 +55,7 @@ export async function validateJellyfinToken(
     const response = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": token,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),
@@ -155,7 +155,7 @@ export async function validateApiKey({
       const response = await fetch(`${getInternalUrl(server)}/System/Info`, {
         method: "GET",
         headers: {
-          "X-Emby-Token": apiKey,
+          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         // Short timeout to avoid hanging requests
@@ -245,13 +245,13 @@ export async function requireApiKey({
  */
 export async function requireSession(): Promise<
   | {
-      error: Response;
-      session: null;
-    }
+    error: Response;
+    session: null;
+  }
   | {
-      error: null;
-      session: SessionUser;
-    }
+    error: null;
+    session: SessionUser;
+  }
 > {
   const session = await getSession();
 
@@ -285,13 +285,13 @@ export async function requireSession(): Promise<
  */
 export async function requireAuth(request: NextRequest): Promise<
   | {
-      error: Response;
-      session: null;
-    }
+    error: Response;
+    session: null;
+  }
   | {
-      error: null;
-      session: SessionUser;
-    }
+    error: null;
+    session: SessionUser;
+  }
 > {
   // Try session cookie first (web app)
   const session = await getSession();
@@ -330,13 +330,13 @@ export async function requireAuth(request: NextRequest): Promise<
  */
 export async function requireAdmin(): Promise<
   | {
-      error: Response;
-      session: null;
-    }
+    error: Response;
+    session: null;
+  }
   | {
-      error: null;
-      session: SessionUser;
-    }
+    error: null;
+    session: SessionUser;
+  }
 > {
   const result = await requireSession();
 

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -55,7 +55,7 @@ export async function validateJellyfinToken(
     const response = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),
@@ -155,7 +155,7 @@ export async function validateApiKey({
       const response = await fetch(`${getInternalUrl(server)}/System/Info`, {
         method: "GET",
         headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         // Short timeout to avoid hanging requests

--- a/apps/nextjs-app/lib/auth.ts
+++ b/apps/nextjs-app/lib/auth.ts
@@ -5,6 +5,7 @@ import "server-only";
 import { cookies } from "next/headers";
 import { shouldUseSecureCookies } from "@/lib/secure-cookies";
 import { getServerWithSecrets } from "./db/server";
+import { jellyfinHeaders } from "./jellyfin-auth";
 import { getInternalUrl } from "./server-url";
 import { createSession } from "./session";
 
@@ -27,10 +28,7 @@ export const login = async ({
     `${getInternalUrl(server)}/Users/AuthenticateByName`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
-      },
+      headers: jellyfinHeaders(server.apiKey),
       body: JSON.stringify({ Username: username, Pw: password }),
     },
   );

--- a/apps/nextjs-app/lib/auth.ts
+++ b/apps/nextjs-app/lib/auth.ts
@@ -29,7 +29,7 @@ export const login = async ({
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Emby-Token": server.apiKey,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${server.apiKey}"`,
       },
       body: JSON.stringify({ Username: username, Pw: password }),
     },

--- a/apps/nextjs-app/lib/db/mark-watched.ts
+++ b/apps/nextjs-app/lib/db/mark-watched.ts
@@ -121,7 +121,7 @@ export async function markItemWatched(
       {
         method,
         headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/lib/db/mark-watched.ts
+++ b/apps/nextjs-app/lib/db/mark-watched.ts
@@ -13,6 +13,7 @@ import {
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getInternalUrl } from "@/lib/server-url";
 import { getSession } from "@/lib/session";
 
@@ -120,10 +121,7 @@ export async function markItemWatched(
       `${getInternalUrl(server)}/Users/${session.id}/PlayedItems/${itemId}`,
       {
         method,
-        headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
-          "Content-Type": "application/json",
-        },
+        headers: jellyfinHeaders(token),
         signal: AbortSignal.timeout(10000),
       },
     );

--- a/apps/nextjs-app/lib/db/mark-watched.ts
+++ b/apps/nextjs-app/lib/db/mark-watched.ts
@@ -121,7 +121,7 @@ export async function markItemWatched(
       {
         method,
         headers: {
-          "X-Emby-Token": token,
+          "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/lib/db/mark-watched.ts
+++ b/apps/nextjs-app/lib/db/mark-watched.ts
@@ -121,7 +121,7 @@ export async function markItemWatched(
       {
         method,
         headers: {
-          "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(10000),

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -5,6 +5,7 @@ import "server-only";
 import { db, items, jobResults, servers } from "@streamystats/database";
 import type { EmbeddingJobResult, Server } from "@streamystats/database/schema";
 import { and, count, desc, eq, sql } from "drizzle-orm";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import type { ServerPublic } from "@/lib/types";
 
 type ServerPublicSelectRow = Omit<
@@ -670,10 +671,7 @@ export const updateServerConnection = async ({
     try {
       const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
         method: "GET",
-        headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-          "Content-Type": "application/json",
-        },
+        headers: jellyfinHeaders(apiKey),
         signal: AbortSignal.timeout(5000),
       });
 
@@ -720,10 +718,7 @@ export const updateServerConnection = async ({
         `${normalizedUrl}/Users/AuthenticateByName`,
         {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
-          },
+          headers: jellyfinHeaders(apiKey),
           body: JSON.stringify({ Username: username, Pw: password }),
           signal: AbortSignal.timeout(5000),
         },

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -671,7 +671,7 @@ export const updateServerConnection = async ({
       const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
         method: "GET",
         headers: {
-          Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(5000),
@@ -722,7 +722,7 @@ export const updateServerConnection = async ({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+            Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${apiKey}"`,
           },
           body: JSON.stringify({ Username: username, Pw: password }),
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -671,7 +671,7 @@ export const updateServerConnection = async ({
       const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
         method: "GET",
         headers: {
-          "X-Emby-Token": apiKey,
+          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(5000),
@@ -722,7 +722,7 @@ export const updateServerConnection = async ({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "X-Emby-Token": apiKey,
+            "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           },
           body: JSON.stringify({ Username: username, Pw: password }),
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -671,7 +671,7 @@ export const updateServerConnection = async ({
       const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
         method: "GET",
         headers: {
-          "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+          Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           "Content-Type": "application/json",
         },
         signal: AbortSignal.timeout(5000),
@@ -722,7 +722,7 @@ export const updateServerConnection = async ({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
+            Authorization: `MediaBrowser Client="Streamystats", Token="${apiKey}"`,
           },
           body: JSON.stringify({ Username: username, Pw: password }),
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/db/users.ts
+++ b/apps/nextjs-app/lib/db/users.ts
@@ -431,7 +431,7 @@ export const validateAdminWithJellyfin = async (): Promise<boolean> => {
     const response = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": token?.value || "",
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${token?.value || ""}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),
@@ -642,7 +642,7 @@ export const getUserWatchStats = async ({
       if (lastDate) {
         const daysDiff = Math.floor(
           (new Date(currentDate).getTime() - new Date(lastDate).getTime()) /
-            (1000 * 60 * 60 * 24),
+          (1000 * 60 * 60 * 24),
         );
 
         if (daysDiff === 1) {

--- a/apps/nextjs-app/lib/db/users.ts
+++ b/apps/nextjs-app/lib/db/users.ts
@@ -431,7 +431,7 @@ export const validateAdminWithJellyfin = async (): Promise<boolean> => {
     const response = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${token?.value || ""}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${token?.value || ""}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),
@@ -642,7 +642,7 @@ export const getUserWatchStats = async ({
       if (lastDate) {
         const daysDiff = Math.floor(
           (new Date(currentDate).getTime() - new Date(lastDate).getTime()) /
-          (1000 * 60 * 60 * 24),
+            (1000 * 60 * 60 * 24),
         );
 
         if (daysDiff === 1) {

--- a/apps/nextjs-app/lib/db/users.ts
+++ b/apps/nextjs-app/lib/db/users.ts
@@ -16,6 +16,7 @@ import {
   sum,
 } from "drizzle-orm";
 import { cookies } from "next/headers";
+import { jellyfinHeaders } from "@/lib/jellyfin-auth";
 import { getInternalUrl } from "../server-url";
 import { destroySession, getSession } from "../session";
 import { getExclusionSettings } from "./exclusions";
@@ -430,10 +431,7 @@ export const validateAdminWithJellyfin = async (): Promise<boolean> => {
   try {
     const response = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token?.value || ""}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(token?.value || ""),
       signal: AbortSignal.timeout(5000),
     });
 

--- a/apps/nextjs-app/lib/db/users.ts
+++ b/apps/nextjs-app/lib/db/users.ts
@@ -431,7 +431,7 @@ export const validateAdminWithJellyfin = async (): Promise<boolean> => {
     const response = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${token?.value || ""}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token?.value || ""}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -48,7 +48,7 @@ export async function getUserFromEmbyToken(args: {
     const res = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10_000),
@@ -84,7 +84,7 @@ export async function getUserFromEmbyToken(args: {
         {
           method: "GET",
           headers: {
-            "Authorization": `MediaBrowser Client="Streamystats", Token="${args.token.trim()}"`,
+            Authorization: `MediaBrowser Client="Streamystats", Token="${args.token.trim()}"`,
             "Content-Type": "application/json",
           },
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -42,13 +42,13 @@ export async function getUserFromEmbyToken(args: {
 > {
   const serverUrl = normalizeBaseUrl(args.serverUrl);
   const token = args.token.trim();
-  if (!token) return { ok: false, error: "Empty X-Emby-Token" };
+  if (!token) return { ok: false, error: "Empty Authorization header" };
 
   try {
     const res = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": token,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10_000),
@@ -56,7 +56,7 @@ export async function getUserFromEmbyToken(args: {
 
     if (!res.ok) {
       if (res.status === 401) {
-        return { ok: false, error: "Invalid X-Emby-Token" };
+        return { ok: false, error: "Invalid Authorization header" };
       }
       return { ok: false, error: `Jellyfin returned ${res.status}` };
     }
@@ -84,7 +84,7 @@ export async function getUserFromEmbyToken(args: {
         {
           method: "GET",
           headers: {
-            "X-Emby-Token": args.token.trim(),
+            "Authorization": `MediaBrowser Client="Streamystats", Token="${args.token.trim()}"`,
             "Content-Type": "application/json",
           },
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -48,7 +48,7 @@ export async function getUserFromEmbyToken(args: {
     const res = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${token}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(10_000),
@@ -84,7 +84,7 @@ export async function getUserFromEmbyToken(args: {
         {
           method: "GET",
           headers: {
-            Authorization: `MediaBrowser Client="Streamystats", Token="${args.token.trim()}"`,
+            Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${args.token.trim()}"`,
             "Content-Type": "application/json",
           },
           signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -1,3 +1,16 @@
+const STREAMYSTATS_VERSION = "2.16.0"; // x-release-please-version
+
+/**
+ * Build the standard Jellyfin Authorization header.
+ * Uses MediaBrowser format required by Jellyfin 10.12+ (non-legacy auth).
+ */
+export function jellyfinHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${token}"`,
+    "Content-Type": "application/json",
+  };
+}
+
 type JellyfinUserMeResponse = {
   Id?: string;
   Name?: string;
@@ -47,10 +60,7 @@ export async function getUserFromEmbyToken(args: {
   try {
     const res = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${token}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(token),
       signal: AbortSignal.timeout(10_000),
     });
 
@@ -83,10 +93,7 @@ export async function getUserFromEmbyToken(args: {
         `${normalizeBaseUrl(args.serverUrl)}/System/Info`,
         {
           method: "GET",
-          headers: {
-            Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${args.token.trim()}"`,
-            "Content-Type": "application/json",
-          },
+          headers: jellyfinHeaders(args.token.trim()),
           signal: AbortSignal.timeout(5000),
         },
       );

--- a/apps/nextjs-app/next.config.mjs
+++ b/apps/nextjs-app/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const { version } = require("./../../package.json");
-
 const nextConfig = {
   output: "standalone",
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
@@ -27,9 +25,6 @@ const nextConfig = {
     serverActions: {
       bodySizeLimit: "500mb",
     },
-  },
-  env: {
-    version,
   },
 };
 

--- a/apps/nextjs-app/next.config.mjs
+++ b/apps/nextjs-app/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const { version } = require("./../../package.json");
+
 const nextConfig = {
   output: "standalone",
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
@@ -25,6 +27,9 @@ const nextConfig = {
     serverActions: {
       bodySizeLimit: "500mb",
     },
+  },
+  env: {
+    version,
   },
 };
 

--- a/apps/nextjs-app/proxy.ts
+++ b/apps/nextjs-app/proxy.ts
@@ -245,7 +245,7 @@ const validateJellyfinToken = async (
     const jellyfinResponse = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Token="${tokenCookie.value}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${tokenCookie.value}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/proxy.ts
+++ b/apps/nextjs-app/proxy.ts
@@ -78,17 +78,17 @@ enum ResultType {
 
 type Result<T> =
   | {
-    type: ResultType.Success;
-    data: T;
-  }
+      type: ResultType.Success;
+      data: T;
+    }
   | {
-    type: ResultType.Error;
-    error: string;
-  }
+      type: ResultType.Error;
+      error: string;
+    }
   | {
-    type: ResultType.ServerConnectivityError;
-    error: string;
-  };
+      type: ResultType.ServerConnectivityError;
+      error: string;
+    };
 
 export const config = {
   matcher: [
@@ -124,9 +124,9 @@ const BASE_PATH_REGEX = basePath.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
 const parsePathname = (pathname: string) => {
   const segments = basePath
     ? pathname
-      .replace(new RegExp(`^${BASE_PATH_REGEX}`), "")
-      .split("/")
-      .filter(Boolean)
+        .replace(new RegExp(`^${BASE_PATH_REGEX}`), "")
+        .split("/")
+        .filter(Boolean)
     : pathname.split("/").filter(Boolean);
 
   // Handle /setup
@@ -245,7 +245,7 @@ const validateJellyfinToken = async (
     const jellyfinResponse = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        "Authorization": `MediaBrowser Client="Streamystats", Token="${tokenCookie.value}"`,
+        Authorization: `MediaBrowser Client="Streamystats", Token="${tokenCookie.value}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/apps/nextjs-app/proxy.ts
+++ b/apps/nextjs-app/proxy.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { basePath } from "@/lib/utils";
 import { getServer, getServers } from "./lib/db/server";
+import { jellyfinHeaders } from "./lib/jellyfin-auth";
 import { getInternalUrl } from "./lib/server-url";
 
 const SECURITY_HEADERS: Record<string, string> = {
@@ -244,10 +245,7 @@ const validateJellyfinToken = async (
   try {
     const jellyfinResponse = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
-      headers: {
-        Authorization: `MediaBrowser Client="Streamystats", Version="${process.env.version}", Token="${tokenCookie.value}"`,
-        "Content-Type": "application/json",
-      },
+      headers: jellyfinHeaders(tokenCookie.value),
       signal: AbortSignal.timeout(5000),
     });
 

--- a/apps/nextjs-app/proxy.ts
+++ b/apps/nextjs-app/proxy.ts
@@ -78,17 +78,17 @@ enum ResultType {
 
 type Result<T> =
   | {
-      type: ResultType.Success;
-      data: T;
-    }
+    type: ResultType.Success;
+    data: T;
+  }
   | {
-      type: ResultType.Error;
-      error: string;
-    }
+    type: ResultType.Error;
+    error: string;
+  }
   | {
-      type: ResultType.ServerConnectivityError;
-      error: string;
-    };
+    type: ResultType.ServerConnectivityError;
+    error: string;
+  };
 
 export const config = {
   matcher: [
@@ -124,9 +124,9 @@ const BASE_PATH_REGEX = basePath.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
 const parsePathname = (pathname: string) => {
   const segments = basePath
     ? pathname
-        .replace(new RegExp(`^${BASE_PATH_REGEX}`), "")
-        .split("/")
-        .filter(Boolean)
+      .replace(new RegExp(`^${BASE_PATH_REGEX}`), "")
+      .split("/")
+      .filter(Boolean)
     : pathname.split("/").filter(Boolean);
 
   // Handle /setup
@@ -245,7 +245,7 @@ const validateJellyfinToken = async (
     const jellyfinResponse = await fetch(`${getInternalUrl(server)}/Users/Me`, {
       method: "GET",
       headers: {
-        "X-Emby-Token": tokenCookie.value,
+        "Authorization": `MediaBrowser Client="Streamystats", Token="${tokenCookie.value}"`,
         "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(5000),

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,12 @@
     ".": {
       "release-type": "node",
       "package-name": "streamystats-v2",
-      "extra-files": ["CHANGELOG.md"],
+      "extra-files": ["CHANGELOG.md",
+        {
+          "type": "generic",
+          "path": "apps/job-server/src/jobs/server-jobs.ts"
+        }
+      ],
       "include-v-in-tag": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
@@ -26,7 +31,7 @@
       "package-name": "@streamystats/nextjs-app"
     },
     "apps/job-server": {
-      "release-type": "node", 
+      "release-type": "node",
       "package-name": "@streamystats/job-server"
     },
     "packages/database": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,10 @@
         {
           "type": "generic",
           "path": "apps/job-server/src/jobs/server-jobs.ts"
+        },
+        {
+          "type": "generic",
+          "path": "apps/nextjs-app/lib/jellyfin-auth.ts"
         }
       ],
       "include-v-in-tag": true,


### PR DESCRIPTION
## Summary
- Replace all legacy `X-Emby-Token` headers with standard `Authorization: MediaBrowser` format required by Jellyfin 10.12+
- Centralize header construction in `jellyfinHeaders()` helper in `lib/jellyfin-auth.ts`
- Add `x-release-please-version` tag for automated version bumps

Closes #339
Supersedes #373

## Summary by Sourcery

Migrate all Jellyfin API calls to use the standard MediaBrowser Authorization header format and centralize header construction for both the Next.js app and job server.

Bug Fixes:
- Ensure compatibility with Jellyfin 10.12+ by replacing legacy X-Emby-Token usage with the required Authorization: MediaBrowser header across all Jellyfin requests.
- Improve error messaging around missing or invalid Jellyfin authorization tokens.

Enhancements:
- Introduce a shared jellyfinHeaders() helper to standardize Jellyfin request headers in the Next.js app.
- Reuse a shared STREAMYSTATS_VERSION constant for MediaBrowser client versioning in job-server Jellyfin requests.

Build:
- Add x-release-please-version markers to support automated version bumping via release-please.