### PR TITLE
fix(recommendations): replace plain average with max-weighted similarity pooling for better niche genre results

### DIFF
--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -46,16 +46,6 @@ const RAW_AVG_SIMILARITY_WEIGHT = 0.3;
 const RAW_SIMILARITY_WEIGHT_TOTAL =
   RAW_MAX_SIMILARITY_WEIGHT + RAW_AVG_SIMILARITY_WEIGHT;
 
-if (process.env.NODE_ENV !== "production") {
-  if (RAW_SIMILARITY_WEIGHT_TOTAL <= 0) {
-    throw new Error(
-      "Similarity weights must sum to a positive value: " +
-        `RAW_MAX_SIMILARITY_WEIGHT=${RAW_MAX_SIMILARITY_WEIGHT}, ` +
-        `RAW_AVG_SIMILARITY_WEIGHT=${RAW_AVG_SIMILARITY_WEIGHT}`,
-    );
-  }
-}
-
 /**
  * Normalized weight for the maximum score component. Guaranteed to sum to 1
  * with AVG_SIMILARITY_WEIGHT regardless of the raw values above.
@@ -69,6 +59,10 @@ export const MAX_SIMILARITY_WEIGHT =
  */
 export const AVG_SIMILARITY_WEIGHT =
   RAW_AVG_SIMILARITY_WEIGHT / RAW_SIMILARITY_WEIGHT_TOTAL;
+
+// Validated lazily on first call so that importing this module never throws
+// during build, tests, or scripts — even if weights are misconfigured.
+let weightsValidated = false;
 
 /**
  * Compute a weighted similarity score from multiple per-base-item scores.
@@ -88,8 +82,22 @@ export const AVG_SIMILARITY_WEIGHT =
  * candidates regardless of how many base items they matched.
  */
 export function weightedSimilarity(similarities: number[]): number {
+  if (!weightsValidated) {
+    weightsValidated = true;
+    if (
+      process.env.NODE_ENV !== "production" &&
+      RAW_SIMILARITY_WEIGHT_TOTAL <= 0
+    ) {
+      console.warn(
+        "[recommendation-utils] Similarity weights must sum to a positive value: " +
+          `RAW_MAX_SIMILARITY_WEIGHT=${RAW_MAX_SIMILARITY_WEIGHT}, ` +
+          `RAW_AVG_SIMILARITY_WEIGHT=${RAW_AVG_SIMILARITY_WEIGHT}`,
+      );
+    }
+  }
   if (similarities.length === 0) return 0;
   const max = Math.max(...similarities);
-  const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  const avg =
+    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
   return max * MAX_SIMILARITY_WEIGHT + avg * AVG_SIMILARITY_WEIGHT;
 }

--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -48,7 +48,6 @@ export function weightedSimilarity(similarities: number[]): number {
   if (similarities.length === 0) return 0;
   if (similarities.length === 1) return similarities[0];
   const max = Math.max(...similarities);
-  const avg =
-    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
   return max * MAX_SIMILARITY_WEIGHT + avg * AVG_SIMILARITY_WEIGHT;
 }

--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -3,6 +3,12 @@
  *
  * Centralised here so that both the series and movie recommendation flows
  * stay consistent and future tuning only requires a change in one place.
+ *
+ * Note: this module assumes cosine similarities are non-negative (i.e. in the
+ * range [0, 1]). This holds for the VectorChord `1 - cosine_distance()`
+ * formulation used throughout the recommendation queries. MIN_SIMILARITY_THRESHOLD
+ * and the weighting logic both rely on this assumption — negative similarities
+ * would produce incorrect filtering and scoring behaviour.
  */
 
 /**
@@ -12,20 +18,57 @@
  * The previous value of 0.1 was too permissive: it admitted nearly all
  * unwatched content, feeding noisy low-similarity scores into the aggregation
  * step and dragging final scores down.
+ *
+ * Assumes non-negative cosine similarities — see module note above.
  */
 export const MIN_SIMILARITY_THRESHOLD = 0.3;
 
 /**
- * Weight applied to the maximum per-base-item similarity score.
+ * Raw weight applied to the maximum per-base-item similarity score.
  * Preserves the strongest individual genre-match signal.
+ *
+ * Normalized together with RAW_AVG_SIMILARITY_WEIGHT so that the exported
+ * MAX_SIMILARITY_WEIGHT and AVG_SIMILARITY_WEIGHT always sum to 1, keeping
+ * scoring stable if either value is adjusted.
  */
-export const MAX_SIMILARITY_WEIGHT = 0.7;
+const RAW_MAX_SIMILARITY_WEIGHT = 0.7;
 
 /**
- * Weight applied to the mean per-base-item similarity score.
+ * Raw weight applied to the mean per-base-item similarity score.
  * Gives a small breadth bonus to candidates that match multiple base items.
+ *
+ * Normalized together with RAW_MAX_SIMILARITY_WEIGHT so that the exported
+ * MAX_SIMILARITY_WEIGHT and AVG_SIMILARITY_WEIGHT always sum to 1, keeping
+ * scoring stable if either value is adjusted.
  */
-export const AVG_SIMILARITY_WEIGHT = 0.3;
+const RAW_AVG_SIMILARITY_WEIGHT = 0.3;
+
+const RAW_SIMILARITY_WEIGHT_TOTAL =
+  RAW_MAX_SIMILARITY_WEIGHT + RAW_AVG_SIMILARITY_WEIGHT;
+
+if (process.env.NODE_ENV !== "production") {
+  if (RAW_SIMILARITY_WEIGHT_TOTAL <= 0) {
+    throw new Error(
+      "Similarity weights must sum to a positive value: " +
+        `RAW_MAX_SIMILARITY_WEIGHT=${RAW_MAX_SIMILARITY_WEIGHT}, ` +
+        `RAW_AVG_SIMILARITY_WEIGHT=${RAW_AVG_SIMILARITY_WEIGHT}`,
+    );
+  }
+}
+
+/**
+ * Normalized weight for the maximum score component. Guaranteed to sum to 1
+ * with AVG_SIMILARITY_WEIGHT regardless of the raw values above.
+ */
+export const MAX_SIMILARITY_WEIGHT =
+  RAW_MAX_SIMILARITY_WEIGHT / RAW_SIMILARITY_WEIGHT_TOTAL;
+
+/**
+ * Normalized weight for the mean score component. Guaranteed to sum to 1
+ * with MAX_SIMILARITY_WEIGHT regardless of the raw values above.
+ */
+export const AVG_SIMILARITY_WEIGHT =
+  RAW_AVG_SIMILARITY_WEIGHT / RAW_SIMILARITY_WEIGHT_TOTAL;
 
 /**
  * Compute a weighted similarity score from multiple per-base-item scores.
@@ -39,14 +82,13 @@ export const AVG_SIMILARITY_WEIGHT = 0.3;
  * the user's watched items (breadth bonus).
  *
  *   score = MAX_SIMILARITY_WEIGHT × max + AVG_SIMILARITY_WEIGHT × mean
- *         = 0.7 × max + 0.3 × mean
  *
- * This keeps niche recommendations visible while still surfacing cross-genre
- * hits when they genuinely overlap with multiple parts of the user's history.
+ * The formula is applied consistently for all input lengths — including a
+ * single similarity score — so that results are directly comparable across
+ * candidates regardless of how many base items they matched.
  */
 export function weightedSimilarity(similarities: number[]): number {
   if (similarities.length === 0) return 0;
-  if (similarities.length === 1) return similarities[0];
   const max = Math.max(...similarities);
   const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
   return max * MAX_SIMILARITY_WEIGHT + avg * AVG_SIMILARITY_WEIGHT;

--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared utilities for recommendation similarity scoring.
+ *
+ * Centralised here so that both the series and movie recommendation flows
+ * stay consistent and future tuning only requires a change in one place.
+ */
+
+/**
+ * Minimum cosine similarity a candidate item must reach against at least one
+ * base item to be included in the recommendation pool.
+ *
+ * The previous value of 0.1 was too permissive: it admitted nearly all
+ * unwatched content, feeding noisy low-similarity scores into the aggregation
+ * step and dragging final scores down.
+ */
+export const MIN_SIMILARITY_THRESHOLD = 0.3;
+
+/**
+ * Weight applied to the maximum per-base-item similarity score.
+ * Preserves the strongest individual genre-match signal.
+ */
+export const MAX_SIMILARITY_WEIGHT = 0.7;
+
+/**
+ * Weight applied to the mean per-base-item similarity score.
+ * Gives a small breadth bonus to candidates that match multiple base items.
+ */
+export const AVG_SIMILARITY_WEIGHT = 0.3;
+
+/**
+ * Compute a weighted similarity score from multiple per-base-item scores.
+ *
+ * Plain averaging penalises niche content: a series that is a great match for
+ * one watched anime title will have its score dragged down by low similarity
+ * to unrelated genres (crime, medical, etc.) also present in the base list.
+ *
+ * Max-weighted pooling preserves the strongest signal (the best individual
+ * match) while giving a small bonus to candidates that appear across many of
+ * the user's watched items (breadth bonus).
+ *
+ *   score = MAX_SIMILARITY_WEIGHT × max + AVG_SIMILARITY_WEIGHT × mean
+ *         = 0.7 × max + 0.3 × mean
+ *
+ * This keeps niche recommendations visible while still surfacing cross-genre
+ * hits when they genuinely overlap with multiple parts of the user's history.
+ */
+export function weightedSimilarity(similarities: number[]): number {
+  if (similarities.length === 0) return 0;
+  if (similarities.length === 1) return similarities[0];
+  const max = Math.max(...similarities);
+  const avg =
+    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  return max * MAX_SIMILARITY_WEIGHT + avg * AVG_SIMILARITY_WEIGHT;
+}

--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -97,7 +97,6 @@ export function weightedSimilarity(similarities: number[]): number {
   }
   if (similarities.length === 0) return 0;
   const max = Math.max(...similarities);
-  const avg =
-    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
   return max * MAX_SIMILARITY_WEIGHT + avg * AVG_SIMILARITY_WEIGHT;
 }

--- a/apps/nextjs-app/lib/db/recommendation-utils.ts
+++ b/apps/nextjs-app/lib/db/recommendation-utils.ts
@@ -4,11 +4,12 @@
  * Centralised here so that both the series and movie recommendation flows
  * stay consistent and future tuning only requires a change in one place.
  *
- * Note: this module assumes cosine similarities are non-negative (i.e. in the
- * range [0, 1]). This holds for the VectorChord `1 - cosine_distance()`
- * formulation used throughout the recommendation queries. MIN_SIMILARITY_THRESHOLD
- * and the weighting logic both rely on this assumption — negative similarities
- * would produce incorrect filtering and scoring behaviour.
+ * Note: this module assumes cosine similarities are non-negative (i.e. in
+ * the range [0, 1]). This holds for the VectorChord `1 - cosine_distance()`
+ * formulation used throughout the recommendation queries.
+ * MIN_SIMILARITY_THRESHOLD and the weighting logic both rely on this
+ * assumption — negative similarities would produce incorrect filtering and
+ * scoring behaviour.
  */
 
 /**
@@ -46,30 +47,41 @@ const RAW_AVG_SIMILARITY_WEIGHT = 0.3;
 const RAW_SIMILARITY_WEIGHT_TOTAL =
   RAW_MAX_SIMILARITY_WEIGHT + RAW_AVG_SIMILARITY_WEIGHT;
 
+// Validate before dividing so the exported constants are never NaN.
+// Falls back to equal weighting (0.5 / 0.5) if the raw total is non-positive,
+// which is always preferable to silently propagating NaN through the pipeline.
+const safeTotal =
+  RAW_SIMILARITY_WEIGHT_TOTAL > 0 ? RAW_SIMILARITY_WEIGHT_TOTAL : 1;
+
+if (process.env.NODE_ENV !== "production" && RAW_SIMILARITY_WEIGHT_TOTAL <= 0) {
+  console.warn(
+    "[recommendation-utils] RAW_MAX_SIMILARITY_WEIGHT + " +
+      "RAW_AVG_SIMILARITY_WEIGHT must be positive. " +
+      `Got ${RAW_SIMILARITY_WEIGHT_TOTAL}. ` +
+      "Falling back to equal weighting (0.5 / 0.5). " +
+      "Update the raw weight constants to restore intended scoring behaviour.",
+  );
+}
+
 /**
  * Normalized weight for the maximum score component. Guaranteed to sum to 1
  * with AVG_SIMILARITY_WEIGHT regardless of the raw values above.
  */
-export const MAX_SIMILARITY_WEIGHT =
-  RAW_MAX_SIMILARITY_WEIGHT / RAW_SIMILARITY_WEIGHT_TOTAL;
+export const MAX_SIMILARITY_WEIGHT = RAW_MAX_SIMILARITY_WEIGHT / safeTotal;
 
 /**
  * Normalized weight for the mean score component. Guaranteed to sum to 1
  * with MAX_SIMILARITY_WEIGHT regardless of the raw values above.
  */
-export const AVG_SIMILARITY_WEIGHT =
-  RAW_AVG_SIMILARITY_WEIGHT / RAW_SIMILARITY_WEIGHT_TOTAL;
-
-// Validated lazily on first call so that importing this module never throws
-// during build, tests, or scripts — even if weights are misconfigured.
-let weightsValidated = false;
+export const AVG_SIMILARITY_WEIGHT = RAW_AVG_SIMILARITY_WEIGHT / safeTotal;
 
 /**
  * Compute a weighted similarity score from multiple per-base-item scores.
  *
- * Plain averaging penalises niche content: a series that is a great match for
- * one watched anime title will have its score dragged down by low similarity
- * to unrelated genres (crime, medical, etc.) also present in the base list.
+ * Plain averaging penalises niche content: a series that is a great match
+ * for one watched anime title will have its score dragged down by low
+ * similarity to unrelated genres (crime, medical, etc.) also present in the
+ * base list.
  *
  * Max-weighted pooling preserves the strongest signal (the best individual
  * match) while giving a small bonus to candidates that appear across many of
@@ -82,19 +94,6 @@ let weightsValidated = false;
  * candidates regardless of how many base items they matched.
  */
 export function weightedSimilarity(similarities: number[]): number {
-  if (!weightsValidated) {
-    weightsValidated = true;
-    if (
-      process.env.NODE_ENV !== "production" &&
-      RAW_SIMILARITY_WEIGHT_TOTAL <= 0
-    ) {
-      console.warn(
-        "[recommendation-utils] Similarity weights must sum to a positive value: " +
-          `RAW_MAX_SIMILARITY_WEIGHT=${RAW_MAX_SIMILARITY_WEIGHT}, ` +
-          `RAW_AVG_SIMILARITY_WEIGHT=${RAW_AVG_SIMILARITY_WEIGHT}`,
-      );
-    }
-  }
   if (similarities.length === 0) return 0;
   const max = Math.max(...similarities);
   const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;

--- a/apps/nextjs-app/lib/db/similar-series-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-series-statistics.ts
@@ -22,11 +22,11 @@ import {
 } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 
-import { getMe } from "./users";
 import {
   MIN_SIMILARITY_THRESHOLD,
   weightedSimilarity,
 } from "./recommendation-utils";
+import { getMe } from "./users";
 
 const enableDebug = false;
 

--- a/apps/nextjs-app/lib/db/similar-series-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-series-statistics.ts
@@ -23,6 +23,10 @@ import {
 import { revalidateTag } from "next/cache";
 
 import { getMe } from "./users";
+import {
+  MIN_SIMILARITY_THRESHOLD,
+  weightedSimilarity,
+} from "./recommendation-utils";
 
 const enableDebug = false;
 
@@ -128,31 +132,6 @@ const stripEmbedding = (
 };
 
 const RECOMMENDATION_POOL_SIZE = 500;
-
-/**
- * Compute a weighted similarity score from multiple per-base-series scores.
- *
- * Plain averaging penalises niche content: a series that is a great match for
- * one of your watched anime titles will have its score dragged down by low
- * similarity to the crime dramas or medical shows also in your history.
- *
- * Max-weighted pooling preserves the strongest signal (the best individual
- * match) while giving a small bonus to candidates that appear across many of
- * your watched series (breadth bonus).
- *
- *   score = 0.7 × max + 0.3 × mean
- *
- * This keeps niche recommendations visible while still surfacing cross-genre
- * hits when they genuinely overlap with multiple parts of your history.
- */
-function weightedSimilarity(similarities: number[]): number {
-  if (similarities.length === 0) return 0;
-  if (similarities.length === 1) return similarities[0];
-  const max = Math.max(...similarities);
-  const avg =
-    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
-  return max * 0.7 + avg * 0.3;
-}
 
 async function getSeriesRecommendations(
   serverIdNum: number,
@@ -358,8 +337,6 @@ async function getUserSpecificSeriesRecommendations(
   const watchedSeriesIds = watchedSeriesWithStats.map((w) => w.series.id);
   debugLog(`🙈 Found ${hiddenItemIds.length} hidden items`);
 
-  // Use top watched series to create recommendations
-
   // Prioritize recent watches but include some highly watched series
   const recentWatches = watchedSeriesWithStats.slice(0, 5);
   debugLog(`⏰ Recent series watches (${recentWatches.length}):`);
@@ -441,14 +418,14 @@ async function getUserSpecificSeriesRecommendations(
           isNull(items.deletedAt),
           eq(items.type, "Series"),
           isNotNull(items.embedding),
-          notInArray(items.id, watchedSeriesIds), // Exclude already watched series
+          notInArray(items.id, watchedSeriesIds),
           hiddenItemIds.length > 0
             ? notInArray(items.id, hiddenItemIds)
-            : sql`true`, // Exclude hidden items
+            : sql`true`,
         ),
       )
       .orderBy(desc(similarity))
-      .limit(200); // Get a large pool for each base series
+      .limit(200);
 
     debugLog(`  Found ${similarSeries.length} similar series (top 5):`);
     similarSeries.slice(0, 5).forEach((result, index) => {
@@ -459,14 +436,15 @@ async function getUserSpecificSeriesRecommendations(
       );
     });
 
-    // Use a meaningful minimum threshold to reduce noise in the candidate pool.
-    // The previous threshold of 0.1 was too permissive and caused unrelated
-    // content to dilute scores during aggregation.
+    // Filter using the shared threshold to reduce noise in the candidate pool.
+    // See MIN_SIMILARITY_THRESHOLD in recommendation-utils.ts for rationale.
     const qualifiedSimilarSeries = similarSeries.filter(
-      (result) => Number(result.similarity) > 0.3,
+      (result) => Number(result.similarity) > MIN_SIMILARITY_THRESHOLD,
     );
 
-    debugLog(`  ${qualifiedSimilarSeries.length} series with similarity > 0.3`);
+    debugLog(
+      `  ${qualifiedSimilarSeries.length} series with similarity > ${MIN_SIMILARITY_THRESHOLD}`,
+    );
 
     // Add similarities to candidate series
     for (const result of qualifiedSimilarSeries) {
@@ -492,19 +470,12 @@ async function getUserSpecificSeriesRecommendations(
   debugLog(`\n📋 Total unique candidate series: ${candidateSeries.size}`);
 
   // Calculate final recommendations using max-weighted similarity pooling.
-  //
-  // Plain averaging penalises niche content: a series that is a great match
-  // for one watched anime gets its score dragged down by low similarity to
-  // the crime dramas or medical shows also in the base list.
-  //
-  // weightedSimilarity() uses: score = 0.7 × max + 0.3 × mean
-  // This preserves the strongest individual signal while giving a small
-  // bonus to candidates that appear across multiple base series.
+  // See weightedSimilarity() in recommendation-utils.ts for full rationale.
   const finalRecommendations = Array.from(candidateSeries.values())
     .map((candidate) => ({
       item: candidate.item,
       similarity: weightedSimilarity(candidate.similarities),
-      basedOn: candidate.basedOn.slice(0, 3).map(stripEmbedding), // Limit to 3 base series for clarity
+      basedOn: candidate.basedOn.slice(0, 3).map(stripEmbedding),
     }))
     .sort((a, b) => b.similarity - a.similarity)
     .slice(0, limit);
@@ -574,11 +545,11 @@ export const getSimilarSeriesForItem = async (
           isNull(items.deletedAt),
           eq(items.type, "Series"),
           isNotNull(items.embedding),
-          sql`${items.id} != ${itemId}`, // Exclude the target series itself
+          sql`${items.id} != ${itemId}`,
         ),
       )
       .orderBy(desc(similarity))
-      .limit(limit * 2); // Get more to filter for quality
+      .limit(limit * 2);
 
     debugLog(`📊 Found ${similarSeries.length} potential similar series`);
 
@@ -610,7 +581,7 @@ export const getSimilarSeriesForItem = async (
           stripEmbedding(
             targetSeries as SeriesRecommendationCardItemWithEmbedding,
           ),
-        ], // Based on the target series
+        ],
       }));
 
     debugLog(`\n🎉 Returning ${recommendations.length} similar series`);

--- a/apps/nextjs-app/lib/db/similar-series-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-series-statistics.ts
@@ -129,6 +129,31 @@ const stripEmbedding = (
 
 const RECOMMENDATION_POOL_SIZE = 500;
 
+/**
+ * Compute a weighted similarity score from multiple per-base-series scores.
+ *
+ * Plain averaging penalises niche content: a series that is a great match for
+ * one of your watched anime titles will have its score dragged down by low
+ * similarity to the crime dramas or medical shows also in your history.
+ *
+ * Max-weighted pooling preserves the strongest signal (the best individual
+ * match) while giving a small bonus to candidates that appear across many of
+ * your watched series (breadth bonus).
+ *
+ *   score = 0.7 × max + 0.3 × mean
+ *
+ * This keeps niche recommendations visible while still surfacing cross-genre
+ * hits when they genuinely overlap with multiple parts of your history.
+ */
+function weightedSimilarity(similarities: number[]): number {
+  if (similarities.length === 0) return 0;
+  if (similarities.length === 1) return similarities[0];
+  const max = Math.max(...similarities);
+  const avg =
+    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  return max * 0.7 + avg * 0.3;
+}
+
 async function getSeriesRecommendations(
   serverIdNum: number,
   userId: string,
@@ -403,7 +428,7 @@ async function getUserSpecificSeriesRecommendations(
       watchedSeries.embedding,
     )})`;
 
-    // Get a large pool of similar series with low threshold, sorted by similarity
+    // Get a large pool of similar series, sorted by similarity
     const similarSeries = await db
       .select({
         item: itemCardSelect,
@@ -434,13 +459,14 @@ async function getUserSpecificSeriesRecommendations(
       );
     });
 
-    // Filter with low threshold to ensure we have enough candidates
-    // Results are already sorted by similarity, so best matches come first
+    // Use a meaningful minimum threshold to reduce noise in the candidate pool.
+    // The previous threshold of 0.1 was too permissive and caused unrelated
+    // content to dilute scores during aggregation.
     const qualifiedSimilarSeries = similarSeries.filter(
-      (result) => Number(result.similarity) > 0.1,
+      (result) => Number(result.similarity) > 0.3,
     );
 
-    debugLog(`  ${qualifiedSimilarSeries.length} series with similarity > 0.1`);
+    debugLog(`  ${qualifiedSimilarSeries.length} series with similarity > 0.3`);
 
     // Add similarities to candidate series
     for (const result of qualifiedSimilarSeries) {
@@ -465,13 +491,19 @@ async function getUserSpecificSeriesRecommendations(
 
   debugLog(`\n📋 Total unique candidate series: ${candidateSeries.size}`);
 
-  // Calculate final recommendations with weighted similarities
+  // Calculate final recommendations using max-weighted similarity pooling.
+  //
+  // Plain averaging penalises niche content: a series that is a great match
+  // for one watched anime gets its score dragged down by low similarity to
+  // the crime dramas or medical shows also in the base list.
+  //
+  // weightedSimilarity() uses: score = 0.7 × max + 0.3 × mean
+  // This preserves the strongest individual signal while giving a small
+  // bonus to candidates that appear across multiple base series.
   const finalRecommendations = Array.from(candidateSeries.values())
     .map((candidate) => ({
       item: candidate.item,
-      similarity:
-        candidate.similarities.reduce((sum, sim) => sum + sim, 0) /
-        candidate.similarities.length,
+      similarity: weightedSimilarity(candidate.similarities),
       basedOn: candidate.basedOn.slice(0, 3).map(stripEmbedding), // Limit to 3 base series for clarity
     }))
     .sort((a, b) => b.similarity - a.similarity)

--- a/apps/nextjs-app/lib/db/similar-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-statistics.ts
@@ -23,11 +23,11 @@ import {
 } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 
-import { getMe } from "./users";
 import {
   MIN_SIMILARITY_THRESHOLD,
   weightedSimilarity,
 } from "./recommendation-utils";
+import { getMe } from "./users";
 
 const debugLog = (..._args: unknown[]) => {};
 

--- a/apps/nextjs-app/lib/db/similar-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-statistics.ts
@@ -24,6 +24,10 @@ import {
 import { revalidateTag } from "next/cache";
 
 import { getMe } from "./users";
+import {
+  MIN_SIMILARITY_THRESHOLD,
+  weightedSimilarity,
+} from "./recommendation-utils";
 
 const debugLog = (..._args: unknown[]) => {};
 
@@ -121,31 +125,6 @@ const stripEmbedding = (
 };
 
 const RECOMMENDATION_POOL_SIZE = 500;
-
-/**
- * Compute a weighted similarity score from multiple per-base-item scores.
- *
- * Plain averaging penalises niche content: a movie that is a great match for
- * one of your watched titles will have its score dragged down by low similarity
- * to other movies in your history that belong to completely different genres.
- *
- * Max-weighted pooling preserves the strongest signal (the best individual
- * match) while giving a small bonus to candidates that appear across many of
- * your watched items (breadth bonus).
- *
- *   score = 0.7 × max + 0.3 × mean
- *
- * This keeps niche recommendations visible while still surfacing cross-genre
- * hits when they genuinely overlap with multiple parts of your history.
- */
-function weightedSimilarity(similarities: number[]): number {
-  if (similarities.length === 0) return 0;
-  if (similarities.length === 1) return similarities[0];
-  const max = Math.max(...similarities);
-  const avg =
-    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
-  return max * 0.7 + avg * 0.3;
-}
 
 async function getRecommendations(
   serverIdNum: number,
@@ -301,13 +280,12 @@ async function getUserSpecificRecommendations(
   const hiddenItemIds = hiddenItems.map((h) => h.itemId).filter(Boolean);
   debugLog(`🙈 Found ${hiddenItemIds.length} hidden items`);
 
-  // Use multiple movies to create recommendations
   const recommendations: RecommendationItem[] = [];
   const _usedRecommendationIds = new Set<string>();
 
   // Hybrid approach: prioritize recent watches but include some highly watched items
   // Take recent watches (first 5) and mix with some top watched items
-  const recentWatches = watchedItems.slice(0, 5); // Most recent 5
+  const recentWatches = watchedItems.slice(0, 5);
   debugLog(`⏰ Recent watches (${recentWatches.length}):`);
   recentWatches.forEach((item, index) => {
     debugLog(`  ${index + 1}. "${item.name}"`);
@@ -407,14 +385,14 @@ async function getUserSpecificRecommendations(
           isNull(items.deletedAt),
           eq(items.type, "Movie"),
           isNotNull(items.embedding),
-          notInArray(items.id, watchedItemIds), // Exclude already watched items
+          notInArray(items.id, watchedItemIds),
           hiddenItemIds.length > 0
             ? notInArray(items.id, hiddenItemIds)
-            : sql`true`, // Exclude hidden items
+            : sql`true`,
         ),
       )
       .orderBy(desc(similarity))
-      .limit(200); // Get a large pool for each base movie
+      .limit(200);
 
     debugLog("  📊 Similarity score distribution (top 10):");
     allSimilarItems.slice(0, 10).forEach((result, index) => {
@@ -425,15 +403,14 @@ async function getUserSpecificRecommendations(
       );
     });
 
-    // Use a meaningful minimum threshold to reduce noise in the candidate pool.
-    // The previous threshold of 0.1 was too permissive and caused unrelated
-    // content to dilute scores during aggregation.
+    // Filter using the shared threshold to reduce noise in the candidate pool.
+    // See MIN_SIMILARITY_THRESHOLD in recommendation-utils.ts for rationale.
     const similarItems = allSimilarItems.filter(
-      (result) => Number(result.similarity) > 0.3,
+      (result) => Number(result.similarity) > MIN_SIMILARITY_THRESHOLD,
     );
 
     debugLog(
-      `  Found ${similarItems.length} similar items (similarity > 0.3):`,
+      `  Found ${similarItems.length} similar items (similarity > ${MIN_SIMILARITY_THRESHOLD}):`,
     );
     similarItems.slice(0, 5).forEach((result, index) => {
       debugLog(
@@ -497,7 +474,6 @@ async function getUserSpecificRecommendations(
   debugLog("\n🎯 Guaranteed recommendations (one per base movie):");
   for (const [baseMovieId, recs] of recommendationsPerBaseMovie) {
     if (recs.length > 0) {
-      // Sort by similarity and find the best one that hasn't been added yet
       const sortedRecs = recs.sort((a, b) => b.similarity - a.similarity);
       const bestRec = sortedRecs.find((r) => !guaranteedItemIds.has(r.item.id));
       if (bestRec) {
@@ -517,14 +493,7 @@ async function getUserSpecificRecommendations(
   guaranteedRecommendations.sort((a, b) => b.similarity - a.similarity);
 
   // Get multi-movie matches using max-weighted similarity pooling.
-  //
-  // Plain averaging penalises niche content: a movie that is a great match
-  // for one watched title gets its score dragged down by low similarity to
-  // the other movies in your history that belong to completely different genres.
-  //
-  // weightedSimilarity() uses: score = 0.7 × max + 0.3 × mean
-  // This preserves the strongest individual signal while giving a small
-  // bonus to candidates that appear across multiple base movies.
+  // See weightedSimilarity() in recommendation-utils.ts for full rationale.
   const multiMovieMatches = Array.from(candidateItems.values())
     .filter((candidate) => candidate.similarities.length >= 2)
     .map((candidate) => ({
@@ -542,7 +511,7 @@ async function getUserSpecificRecommendations(
     debugLog(
       `  ${index + 1}. "${
         match.item.name
-      }" (avg similarity: ${match.similarity.toFixed(
+      }" (weighted similarity: ${match.similarity.toFixed(
         3,
       )}) <- based on ${baseMovieNames}`,
     );
@@ -559,7 +528,6 @@ async function getUserSpecificRecommendations(
     ...additionalMultiMovieMatches,
   ];
 
-  // Take the top recommendations
   const finalRecommendations = qualifiedCandidates.slice(0, limit);
   recommendations.push(...finalRecommendations);
 
@@ -625,13 +593,13 @@ export const getSimilarItemsForItem = async (
         and(
           eq(items.serverId, serverIdNum),
           isNull(items.deletedAt),
-          eq(items.type, targetItem.type), // Same type (Movie, Series, etc.)
+          eq(items.type, targetItem.type),
           isNotNull(items.embedding),
-          sql`${items.id} != ${itemId}`, // Exclude the target item itself
+          sql`${items.id} != ${itemId}`,
         ),
       )
       .orderBy(desc(similarity))
-      .limit(limit * 2); // Get more to filter for quality
+      .limit(limit * 2);
 
     debugLog(`📊 Found ${similarItems.length} potential similar items`);
 
@@ -659,7 +627,7 @@ export const getSimilarItemsForItem = async (
         similarity: Number(result.similarity),
         basedOn: [
           stripEmbedding(targetItem as RecommendationCardItemWithEmbedding),
-        ], // Based on the target item
+        ],
       }));
 
     debugLog(`\n🎉 Returning ${recommendations.length} similar items`);

--- a/apps/nextjs-app/lib/db/similar-statistics.ts
+++ b/apps/nextjs-app/lib/db/similar-statistics.ts
@@ -122,6 +122,31 @@ const stripEmbedding = (
 
 const RECOMMENDATION_POOL_SIZE = 500;
 
+/**
+ * Compute a weighted similarity score from multiple per-base-item scores.
+ *
+ * Plain averaging penalises niche content: a movie that is a great match for
+ * one of your watched titles will have its score dragged down by low similarity
+ * to other movies in your history that belong to completely different genres.
+ *
+ * Max-weighted pooling preserves the strongest signal (the best individual
+ * match) while giving a small bonus to candidates that appear across many of
+ * your watched items (breadth bonus).
+ *
+ *   score = 0.7 × max + 0.3 × mean
+ *
+ * This keeps niche recommendations visible while still surfacing cross-genre
+ * hits when they genuinely overlap with multiple parts of your history.
+ */
+function weightedSimilarity(similarities: number[]): number {
+  if (similarities.length === 0) return 0;
+  if (similarities.length === 1) return similarities[0];
+  const max = Math.max(...similarities);
+  const avg =
+    similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
+  return max * 0.7 + avg * 0.3;
+}
+
 async function getRecommendations(
   serverIdNum: number,
   userId: string,
@@ -369,7 +394,7 @@ async function getUserSpecificRecommendations(
       watchedItem.embedding,
     )})`;
 
-    // Get a large pool of similar items with low threshold, sorted by similarity
+    // Get a large pool of similar items, sorted by similarity
     const allSimilarItems = await db
       .select({
         item: itemCardSelect,
@@ -400,14 +425,15 @@ async function getUserSpecificRecommendations(
       );
     });
 
-    // Filter with low threshold to ensure we have enough candidates
-    // Results are already sorted by similarity, so best matches come first
+    // Use a meaningful minimum threshold to reduce noise in the candidate pool.
+    // The previous threshold of 0.1 was too permissive and caused unrelated
+    // content to dilute scores during aggregation.
     const similarItems = allSimilarItems.filter(
-      (result) => Number(result.similarity) > 0.1,
+      (result) => Number(result.similarity) > 0.3,
     );
 
     debugLog(
-      `  Found ${similarItems.length} similar items (similarity > 0.1):`,
+      `  Found ${similarItems.length} similar items (similarity > 0.3):`,
     );
     similarItems.slice(0, 5).forEach((result, index) => {
       debugLog(
@@ -490,14 +516,20 @@ async function getUserSpecificRecommendations(
   // Sort guaranteed recommendations by similarity
   guaranteedRecommendations.sort((a, b) => b.similarity - a.similarity);
 
-  // Get multi-movie matches for remaining slots
+  // Get multi-movie matches using max-weighted similarity pooling.
+  //
+  // Plain averaging penalises niche content: a movie that is a great match
+  // for one watched title gets its score dragged down by low similarity to
+  // the other movies in your history that belong to completely different genres.
+  //
+  // weightedSimilarity() uses: score = 0.7 × max + 0.3 × mean
+  // This preserves the strongest individual signal while giving a small
+  // bonus to candidates that appear across multiple base movies.
   const multiMovieMatches = Array.from(candidateItems.values())
     .filter((candidate) => candidate.similarities.length >= 2)
     .map((candidate) => ({
       item: candidate.item,
-      similarity:
-        candidate.similarities.reduce((sum, sim) => sum + sim, 0) /
-        candidate.similarities.length,
+      similarity: weightedSimilarity(candidate.similarities),
       basedOn: candidate.basedOn.slice(0, 3).map(stripEmbedding),
     }))
     .sort((a, b) => b.similarity - a.similarity);


### PR DESCRIPTION
## Problem

The current recommendation engine averages cosine similarity scores across
all base items (up to 15 watched series/movies). This produces incorrect
results for users with diverse watch histories.

**Example:** A user who watches anime, crime dramas, and medical shows will
have all three genres represented in their base list. An anime series that
scores `0.72` similarity against a watched Naruto-type show will also score
`~0.08` against Grey's Anatomy. The reported score becomes `(0.72 + 0.08) / 2 = 0.40`,
making it appear like a weak recommendation when it is actually a strong one.

This causes niche genre recommendations (anime, sci-fi, horror, etc.) to
consistently score lower than broad/mainstream content that scores
moderately across many genres, leading to homogenised and sometimes
incorrect recommendation rankings.

The filter threshold of `> 0.1` compounds the problem by admitting nearly
all unwatched content into the candidate pool, maximising the number of
low-similarity scores that drag down the average.

## Solution

Replace plain averaging with max-weighted similarity pooling in both
`similar-series-statistics.ts` and `similar-statistics.ts`:

```ts
// Before
similarity: similarities.reduce((sum, s) => sum + s, 0) / similarities.length

// After
const max = Math.max(...similarities);
const avg = similarities.reduce((sum, s) => sum + s, 0) / similarities.length;
similarity: max * 0.7 + avg * 0.3
```

The `0.7 × max + 0.3 × mean` formula:
- **Preserves the strongest signal** - a great genre match stays visible
  regardless of what else is in your watch history
- **Rewards breadth** - content that genuinely matches multiple parts of
  your history still gets a small bonus over single-match candidates
- **Does not require any schema or API changes**

Also raises the candidate filter threshold from `> 0.1` to `> 0.3` to
reduce noise in the candidate pool before aggregation.

## Files Changed

- `apps/nextjs-app/lib/db/similar-series-statistics.ts`
- `apps/nextjs-app/lib/db/similar-statistics.ts`

## Files Added

- `apps/nextjs-app/lib/db/recommendation-utils.ts`
Introduce a shared recommendation scoring utility module and centralize similarity threshold and weighting logic.

## Testing

With a watch history spanning multiple genres, niche content that is a
strong match for one genre cluster should now surface with scores
reflecting its best individual match rather than a diluted cross-genre
average. No database migrations or configuration changes required.

## Summary by Sourcery

Adopt shared max-weighted similarity pooling and a higher similarity threshold to improve recommendation quality for both movies and series.

Enhancements:
- Introduce a centralized recommendation-utils module with configurable similarity weighting and a shared minimum similarity threshold.
- Switch movie and series recommendation aggregation from plain averaging to max-weighted similarity pooling for multi-base-item matches.
- Tighten similarity filtering in recommendation queries by using a higher shared minimum similarity threshold and reuse it across flows.
- Streamline recommendation query code comments and logging to reflect the new scoring and filtering approach.