### PR TITLE
fix: prevent scheduler job loop by using unique schedule keys

### DIFF
--- a/apps/job-server/src/jellyfin/sync/activities.ts
+++ b/apps/job-server/src/jellyfin/sync/activities.ts
@@ -459,6 +459,7 @@ export async function syncRecentActivities(
     );
 
     if (intelligent && mostRecentDbActivityId && !foundLastKnownActivity) {
+      const warningMessage = `Intelligent sync did not find last known activity (id: ${mostRecentDbActivityId}) within ${pagesFetched} pages. The activity may be older than the fetched data.`;
       console.info(
         formatSyncLogLine("recent-activities-sync", {
           server: server.name,
@@ -470,9 +471,17 @@ export async function syncRecentActivities(
           processMs: 0,
           totalProcessed: finalMetrics.activitiesProcessed,
           intelligent,
-          message: "Intelligent sync did not find last known activity",
+          message: warningMessage,
           lastKnownActivityId: mostRecentDbActivityId,
         })
+      );
+      // Return partial success to prevent immediate re-triggering by pg-boss
+      return createSyncResult(
+        "partial",
+        data,
+        finalMetrics,
+        undefined,
+        [warningMessage]
       );
     }
 

--- a/apps/job-server/src/jellyfin/sync/activities.ts
+++ b/apps/job-server/src/jellyfin/sync/activities.ts
@@ -475,14 +475,9 @@ export async function syncRecentActivities(
           lastKnownActivityId: mostRecentDbActivityId,
         })
       );
-      // Return partial success to prevent immediate re-triggering by pg-boss
-      return createSyncResult(
-        "partial",
-        data,
-        finalMetrics,
-        undefined,
-        [warningMessage]
-      );
+      // Informational condition (the anchor scrolled out of the fetched window),
+      // not a sync error. Fall through to the normal success/partial result
+      // based on `errors` below. The next scheduled run resumes from the cursor.
     }
 
     if (errors.length > 0) {

--- a/apps/job-server/src/jobs/scheduler.ts
+++ b/apps/job-server/src/jobs/scheduler.ts
@@ -207,19 +207,21 @@ class SyncScheduler {
       const typedJobKey = jobKey as JobKey;
       if (!isCronJob(typedJobKey)) continue;
 
-      const scheduleKey = `server-${serverId}`;
+      const scheduleKey = `server-${serverId}-${jobKey}`;
       const cronExpression = this.getEffectiveCron(serverId, typedJobKey);
       const isEnabled = this.isJobEnabledForServer(serverId, typedJobKey);
 
       try {
         if (isEnabled) {
           // Create or update the schedule
+          // Use singletonKey to prevent duplicate job executions across instances
           await boss.schedule(
             config.pgBossName,
             cronExpression,
             config.buildData(serverId),
             {
               key: scheduleKey,
+              singletonKey: scheduleKey,
               ...config.sendOptions,
             }
           );

--- a/apps/job-server/src/jobs/scheduler.ts
+++ b/apps/job-server/src/jobs/scheduler.ts
@@ -185,6 +185,12 @@ class SyncScheduler {
 
     console.log(`[scheduler] syncing schedules for ${allServers.length} servers`);
 
+    // Before re-creating schedules with per-job keys, remove legacy schedules
+    // that used the shared `server-${serverId}` key. Without this, deploys from
+    // older versions leave orphaned schedule rows that keep firing alongside the
+    // new per-job schedules, causing duplicate job executions.
+    await this.cleanupLegacySchedules(allServers.map((s) => s.id));
+
     for (const server of allServers) {
       await this.syncSchedulesForServer(server.id, server.name);
     }
@@ -213,16 +219,17 @@ class SyncScheduler {
 
       try {
         if (isEnabled) {
-          // Create or update the schedule
-          // Use singletonKey to prevent duplicate job executions across instances
+          // Create or update the schedule. singletonKey prevents a new
+          // instance from being queued while the previous one is still active.
+          // Spread sendOptions first so key/singletonKey always take precedence.
           await boss.schedule(
             config.pgBossName,
             cronExpression,
             config.buildData(serverId),
             {
+              ...config.sendOptions,
               key: scheduleKey,
               singletonKey: scheduleKey,
-              ...config.sendOptions,
             }
           );
           console.log(
@@ -242,6 +249,37 @@ class SyncScheduler {
         );
       }
     }
+  }
+
+  /**
+   * Remove legacy per-server schedules that used the shared `server-${serverId}`
+   * key (one row per job name, all sharing the same key). These predate the
+   * per-job `server-${serverId}-${jobKey}` keys and would otherwise keep firing.
+   * unschedule is idempotent, so this is a safe no-op once the cleanup has run.
+   */
+  private async cleanupLegacySchedules(serverIds: number[]): Promise<void> {
+    const boss = await getJobQueue();
+    let removed = 0;
+
+    for (const serverId of serverIds) {
+      const legacyKey = `server-${serverId}`;
+      for (const config of Object.values(SCHEDULER_JOB_CONFIG)) {
+        if (!config) continue;
+        try {
+          await boss.unschedule(config.pgBossName, legacyKey);
+          removed++;
+        } catch (error) {
+          console.error(
+            `[scheduler] failed to remove legacy schedule name=${config.pgBossName} key=${legacyKey}`,
+            error
+          );
+        }
+      }
+    }
+
+    console.log(
+      `[scheduler] phase=legacy-schedule-cleanup attempted=${removed} servers=${serverIds.length}`
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes #456

## Summary by Sourcery

Ensure Jellyfin activity sync jobs and scheduled sync jobs do not loop or duplicate across servers and job types.

Bug Fixes:
- Return a partial success result with a warning when intelligent recent activity sync cannot find the last known activity, preventing immediate re-triggering by pg-boss.
- Use a job-and-server-specific schedule key and singleton key for cron-based sync jobs to avoid duplicate job executions across instances.