### PR TITLE
feat: switch Docker registry from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [main]
 
+permissions:
+  packages: write
+
 env:
-  REGISTRY: docker.io
-  IMAGE_NAMESPACE: ${{ secrets.DOCKER_USERNAME }}
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   build-and-push:
@@ -15,17 +18,17 @@ jobs:
       fail-fast: false
       matrix:
         part:
-          - streamystats-v2-nextjs
-          - streamystats-v2-job-server
-          - streamystats-v2-aio
+          - streamystats-nextjs
+          - streamystats-job-server
+          - streamystats-aio
         include:
-          - part: streamystats-v2-nextjs
+          - part: streamystats-nextjs
             folder: .
             dockerfile: apps/nextjs-app/Dockerfile
-          - part: streamystats-v2-job-server
+          - part: streamystats-job-server
             folder: .
             dockerfile: apps/job-server/Dockerfile
-          - part: streamystats-v2-aio
+          - part: streamystats-aio
             folder: .
             dockerfile: Dockerfile.aio
 
@@ -38,8 +41,8 @@ jobs:
       - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push ${{ matrix.part }}
         uses: docker/build-push-action@v7

--- a/.github/workflows/manual-docker-build.yml
+++ b/.github/workflows/manual-docker-build.yml
@@ -13,9 +13,12 @@ on:
         type: boolean
         default: true
 
+permissions:
+  packages: write
+
 env:
-  REGISTRY: docker.io
-  IMAGE_NAMESPACE: ${{ secrets.DOCKER_USERNAME }}
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   build-and-push:
@@ -24,13 +27,13 @@ jobs:
       fail-fast: false
       matrix:
         part:
-          - streamystats-v2-nextjs
-          - streamystats-v2-job-server
+          - streamystats-nextjs
+          - streamystats-job-server
         include:
-          - part: streamystats-v2-nextjs
+          - part: streamystats-nextjs
             folder: .
             dockerfile: apps/nextjs-app/Dockerfile
-          - part: streamystats-v2-job-server
+          - part: streamystats-job-server
             folder: .
             dockerfile: apps/job-server/Dockerfile
 
@@ -44,13 +47,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         if: ${{ inputs.push_to_registry }}
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
@@ -95,8 +98,8 @@ jobs:
           echo "**Push to Registry:** \`${{ inputs.push_to_registry }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Built Images:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-nextjs:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-job-server:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-nextjs:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-job-server:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Usage:" >> $GITHUB_STEP_SUMMARY
           echo "Update your \`docker-compose.yml\` with:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -5,9 +5,14 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main]
 
+permissions:
+  packages: write
+  pull-requests: write
+  issues: write
+
 env:
-  REGISTRY: docker.io
-  IMAGE_NAMESPACE: ${{ secrets.DOCKER_USERNAME }}
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   lint:
@@ -76,13 +81,13 @@ jobs:
       fail-fast: false
       matrix:
         part:
-          - streamystats-v2-nextjs
-          - streamystats-v2-job-server
+          - streamystats-nextjs
+          - streamystats-job-server
         include:
-          - part: streamystats-v2-nextjs
+          - part: streamystats-nextjs
             folder: .
             dockerfile: apps/nextjs-app/Dockerfile
-          - part: streamystats-v2-job-server
+          - part: streamystats-job-server
             folder: .
             dockerfile: apps/job-server/Dockerfile
 
@@ -96,12 +101,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract PR number
         id: pr
@@ -149,8 +154,8 @@ jobs:
           echo "**Commit SHA:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Built Images:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-nextjs:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-v2-job-server:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-nextjs:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAMESPACE }}/streamystats-job-server:pr-${{ github.event.number }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Usage:" >> $GITHUB_STEP_SUMMARY
           echo "To test this PR, update your \`docker-compose.yml\` with:" >> $GITHUB_STEP_SUMMARY
@@ -168,11 +173,11 @@ jobs:
 
             const comment = `## 🐳 PR Docker Images Built
 
-            Your PR has been built and pushed to Docker Hub with the tag \`pr-${prNumber}\`.
+            Your PR has been built and pushed to GHCR with the tag \`pr-${prNumber}\`.
 
             ### Available Images:
-            - \`${namespace}/streamystats-v2-nextjs:pr-${prNumber}\`
-            - \`${namespace}/streamystats-v2-job-server:pr-${prNumber}\`
+            - \`${namespace}/streamystats-nextjs:pr-${prNumber}\`
+            - \`${namespace}/streamystats-job-server:pr-${prNumber}\`
 
             ### Usage:
             \`\`\`bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:
@@ -33,23 +34,23 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     env:
-      REGISTRY: docker.io
-      IMAGE_NAMESPACE: ${{ secrets.DOCKER_USERNAME }}
+      REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
     strategy:
       fail-fast: false
       matrix:
         part:
-          - streamystats-v2-nextjs
-          - streamystats-v2-job-server
-          - streamystats-v2-aio
+          - streamystats-nextjs
+          - streamystats-job-server
+          - streamystats-aio
         include:
-          - part: streamystats-v2-nextjs
+          - part: streamystats-nextjs
             folder: .
             dockerfile: apps/nextjs-app/Dockerfile
-          - part: streamystats-v2-job-server
+          - part: streamystats-job-server
             folder: .
             dockerfile: apps/job-server/Dockerfile
-          - part: streamystats-v2-aio
+          - part: streamystats-aio
             folder: .
             dockerfile: Dockerfile.aio
     steps:
@@ -62,12 +63,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/AIO.md
+++ b/AIO.md
@@ -26,7 +26,7 @@ docker run -d \
   -v streamystats_data:/var/lib/postgresql/data \
   -e SESSION_SECRET="$(openssl rand -hex 32)" \
   -e POSTGRES_PASSWORD="your-secure-password" \
-  fredrikburmester/streamystats-v2-aio:latest
+  ghcr.io/fredrikburmester/streamystats-aio:latest
 ```
 
 ## Configuration

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configuration
-REGISTRY="docker.io/fredrikburmester"
+REGISTRY="ghcr.io/fredrikburmester"
 VERSION=${VERSION:-latest}
 
 # Colors
@@ -98,20 +98,20 @@ while true; do
             case $selected in
                 0) # NextJS App
                     echo -e "${BLUE}Building NextJS App only...${NC}\n"
-                    build_and_push "apps/nextjs-app/Dockerfile" "streamystats-v2-nextjs" "NextJS app"
+                    build_and_push "apps/nextjs-app/Dockerfile" "streamystats-nextjs" "NextJS app"
                     ;;
                 1) # Job Server
                     echo -e "${BLUE}Building Job Server only...${NC}\n"
-                    build_and_push "apps/job-server/Dockerfile" "streamystats-v2-job-server" "Job server"
+                    build_and_push "apps/job-server/Dockerfile" "streamystats-job-server" "Job server"
                     ;;
                 2) # All Services
                     echo -e "${BLUE}Building all services...${NC}\n"
 
                     # Build in parallel
-                    build_and_push "apps/nextjs-app/Dockerfile" "streamystats-v2-nextjs" "NextJS app" &
+                    build_and_push "apps/nextjs-app/Dockerfile" "streamystats-nextjs" "NextJS app" &
                     NEXTJS_PID=$!
 
-                    build_and_push "apps/job-server/Dockerfile" "streamystats-v2-job-server" "Job server" &
+                    build_and_push "apps/job-server/Dockerfile" "streamystats-job-server" "Job server" &
                     JOBSERVER_PID=$!
 
                     echo -e "\n${YELLOW}Waiting for all builds to complete...${NC}\n"
@@ -131,11 +131,11 @@ while true; do
             echo ""
             echo "Built images:"
             case $selected in
-                0) echo "  - $REGISTRY/streamystats-v2-nextjs:$VERSION" ;;
-                1) echo "  - $REGISTRY/streamystats-v2-job-server:$VERSION" ;;
+                0) echo "  - $REGISTRY/streamystats-nextjs:$VERSION" ;;
+                1) echo "  - $REGISTRY/streamystats-job-server:$VERSION" ;;
                 2)
-                    echo "  - $REGISTRY/streamystats-v2-nextjs:$VERSION"
-                    echo "  - $REGISTRY/streamystats-v2-job-server:$VERSION"
+                    echo "  - $REGISTRY/streamystats-nextjs:$VERSION"
+                    echo "  - $REGISTRY/streamystats-job-server:$VERSION"
                     ;;
             esac
 

--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -10,11 +10,11 @@
 #     -p 3000:3000 \
 #     -v streamystats_data:/var/lib/postgresql/data \
 #     -e SESSION_SECRET="your-secret-here" \
-#     fredrikburmester/streamystats-v2-aio:latest
+#     ghcr.io/fredrikburmester/streamystats-aio:latest
 
 services:
   streamystats:
-    image: docker.io/fredrikburmester/streamystats-v2-aio:${VERSION:-latest}
+    image: ghcr.io/fredrikburmester/streamystats-aio:${VERSION:-latest}
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   nextjs-app:
-    image: docker.io/fredrikburmester/streamystats-v2-nextjs:${VERSION:-latest}
+    image: ghcr.io/fredrikburmester/streamystats-nextjs:${VERSION:-latest}
     ports:
       - "3000:3000"
     environment:
@@ -28,7 +28,7 @@ services:
       - app-network
 
   job-server:
-    image: docker.io/fredrikburmester/streamystats-v2-job-server:${VERSION:-latest}
+    image: ghcr.io/fredrikburmester/streamystats-job-server:${VERSION:-latest}
     environment:
       - NODE_ENV=production
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@vectorchord:5432/${POSTGRES_DB:-streamystats}


### PR DESCRIPTION
## Summary
- Switch all Docker image publishing from `docker.io` to `ghcr.io`
- Drop `-v2` from image names (clean break with new registry)
- Use `GITHUB_TOKEN` for auth instead of `DOCKER_USERNAME`/`DOCKER_TOKEN` secrets
- Add `packages: write` permissions to all workflows

## Upgrade instructions

**Recommended:** Copy the latest `docker-compose.yml` from the repo — it includes new env vars and security hardening since the last release.

If you prefer to update manually, here are the required changes:

### 1. Remove the `migrate` service (now handled by job-server on startup)

```diff
 services:
-  migrate:
-    image: docker.io/fredrikburmester/streamystats-v2-migrate:${VERSION:-latest}
-    ...
-    restart: "no"
-
   nextjs-app:
     depends_on:
-      migrate:
-        condition: service_completed_successfully
       job-server:
         condition: service_healthy

   job-server:
     depends_on:
-      migrate:
-        condition: service_completed_successfully
       vectorchord:
         condition: service_healthy
```

### 2. Update image references

```diff
- image: docker.io/fredrikburmester/streamystats-v2-nextjs:${VERSION:-latest}
+ image: ghcr.io/fredrikburmester/streamystats-nextjs:${VERSION:-latest}

- image: docker.io/fredrikburmester/streamystats-v2-job-server:${VERSION:-latest}
+ image: ghcr.io/fredrikburmester/streamystats-job-server:${VERSION:-latest}
```

AIO users:
```diff
- image: docker.io/fredrikburmester/streamystats-v2-aio:${VERSION:-latest}
+ image: ghcr.io/fredrikburmester/streamystats-aio:${VERSION:-latest}
```

### 3. Recommended additions (if not already present)

- `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` on nextjs-app (prevents session breakage on redeploy)
- `POSTGRES_HOST_AUTH_METHOD=scram-sha-256` on vectorchord (hardens DB auth)
- Cron schedule env vars on job-server (see `docker-compose.yml` in repo for defaults)