### PR TITLE
fix: Anthropic AI chat 404 by not overriding SDK default base URL

### DIFF
--- a/apps/nextjs-app/lib/ai/providers.ts
+++ b/apps/nextjs-app/lib/ai/providers.ts
@@ -91,9 +91,18 @@ export function createChatModel(config: ChatConfig): LanguageModel | null {
       if (!config.apiKey) {
         throw new Error("Anthropic requires an API key");
       }
+      // Only pass baseURL if it differs from the default Anthropic URL.
+      // The SDK internally uses "https://api.anthropic.com/v1" as its base,
+      // but passing "https://api.anthropic.com" as baseURL overrides this
+      // and causes requests to hit /messages instead of /v1/messages.
+      const defaultAnthropicUrl = CHAT_PROVIDER_PRESETS.anthropic.baseUrl;
+      const customBaseUrl =
+        config.baseUrl && config.baseUrl !== defaultAnthropicUrl
+          ? config.baseUrl
+          : undefined;
       const anthropic = createAnthropic({
         apiKey: config.apiKey,
-        baseURL: config.baseUrl || undefined,
+        baseURL: customBaseUrl,
       });
       return anthropic(config.model);
     }


### PR DESCRIPTION
## Summary

- Fixes the Anthropic AI Chat returning "Not Found" (404) when using the default base URL
- The `@ai-sdk/anthropic` SDK internally resolves to `https://api.anthropic.com/v1`, but passing `https://api.anthropic.com` as `baseURL` overrides this and causes requests to hit `/messages` instead of `/v1/messages`
- Only passes `baseURL` to `createAnthropic()` when the user has configured a non-default custom URL

## Test plan

- [ ] Configure AI Chat with Anthropic provider using default base URL (`https://api.anthropic.com`)
- [ ] Send a chat message — should succeed instead of returning "Not Found"
- [ ] Configure with a custom Anthropic-compatible URL — should still pass it through
- [ ] Test button behavior unchanged

Fixes #491

## Summary by Sourcery

Bug Fixes:
- Avoid 404 errors from Anthropic chat by only passing a custom base URL when it differs from the default Anthropic endpoint.