### PR TITLE
chore: ignore ai sdk packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "ai"
+      - dependency-name: "@ai-sdk/*"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
Forcefully ignore `ai` and `@ai-sdk/*` packages from Dependabot updates. These major bumps require manual migration.

## Summary by Sourcery

Build:
- Update Dependabot configuration to exclude `ai` and `@ai-sdk/*` packages from automated dependency updates.