### PR TITLE
fix: remove non-async exports from api-auth server action module

### DIFF
--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -16,8 +16,8 @@ import { getSession, type SessionUser } from "./session";
  * MediaBrowser path here and `getUserFromEmbyToken` in `jellyfin-auth.ts`
  * stay in sync.
  */
-export const SYSTEM_API_KEY_USER_ID = "system-api-key";
-export const SYSTEM_API_KEY_USER_NAME = "System API Key";
+const SYSTEM_API_KEY_USER_ID = "system-api-key";
+const SYSTEM_API_KEY_USER_NAME = "System API Key";
 
 /**
  * Parse MediaBrowser authorization header


### PR DESCRIPTION
The `"use server"` directive in `lib/api-auth.ts` restricts the module to exporting only async functions. PR #515 added two `export const` constants, which made Turbopack reject the whole module (39 build errors, every export reported as "not found"), breaking the docker build on main.

The constants have no external importers, so dropping `export` resolves the build while keeping them available to the only caller, `validateAsApiKey`.

## Summary by Sourcery

Bug Fixes:
- Fix Turbopack build failures by removing exports from non-async constants in the api-auth server action module.