### PR TITLE
fix: authenticate Jellyfin server API keys for MediaBrowser API routes

### DIFF
--- a/apps/nextjs-app/app/api/recommendations/route.ts
+++ b/apps/nextjs-app/app/api/recommendations/route.ts
@@ -1,9 +1,6 @@
 import type { Server } from "@streamystats/database";
 import type { NextRequest } from "next/server";
-import {
-  authenticateMediaBrowser,
-  validateJellyfinToken,
-} from "@/lib/api-auth";
+import { authenticateMediaBrowserForServer } from "@/lib/api-auth";
 import {
   hasServerIdentifier,
   parseServerIdentifier,
@@ -19,6 +16,7 @@ import {
   type RecommendationItem,
 } from "@/lib/db/similar-statistics";
 import { authenticateByName } from "@/lib/jellyfin-auth";
+import { getInternalUrl } from "@/lib/server-url";
 
 type RecommendationType = "Movie" | "Series" | "all";
 type RangePreset = "7d" | "30d" | "90d" | "thisMonth" | "all";
@@ -381,63 +379,25 @@ export async function GET(request: NextRequest) {
     return jsonResponse({ error: "Server not found" }, 404);
   }
 
-  // Try MediaBrowser auth (Authorization: MediaBrowser Token="...")
-  const mediaBrowserAuth = await authenticateMediaBrowser(request);
-  if (!mediaBrowserAuth) {
+  // Authenticate the MediaBrowser token against the requested server.
+  const userInfo = await authenticateMediaBrowserForServer({ request, server });
+  if (!userInfo) {
     return jsonResponse(
       {
         error: "Unauthorized",
         message:
-          'Valid Jellyfin token required. Use Authorization: MediaBrowser Token="..." header.',
+          'Valid Jellyfin token required for the requested server. Use Authorization: MediaBrowser Token="..." header.',
       },
       401,
     );
   }
 
-  // Verify the authenticated server matches the requested server
-  if (mediaBrowserAuth.server.id !== server.id) {
-    // Token is valid but for a different server - try validating against requested server
-    const authHeader = request.headers.get("authorization");
-    const tokenMatch = authHeader?.match(/Token="([^"]*)"/i);
-    const token = tokenMatch?.[1];
-
-    if (token) {
-      const userInfo = await validateJellyfinToken(server.url, token);
-      if (userInfo) {
-        let targetUser: ApiUser = {
-          id: userInfo.userId,
-          name: userInfo.userName,
-        };
-        if (userInfo.isAdmin && parsed.targetUserId) {
-          targetUser = { id: parsed.targetUserId, name: null };
-        }
-        const payload = await buildRecommendationsResponse({
-          server,
-          user: targetUser,
-          params: parsed.params,
-          timeWindow: parsed.timeWindow,
-        });
-        return jsonResponse(payload, 200);
-      }
-    }
-
-    return jsonResponse(
-      {
-        error: "Unauthorized",
-        message: "Token is not valid for the requested server.",
-      },
-      401,
-    );
-  }
-
-  // DEFAULT: Use the authenticated user
+  // DEFAULT: the authenticated user. OVERRIDE: an admin may target another.
   let targetUser: ApiUser = {
-    id: mediaBrowserAuth.session.id,
-    name: mediaBrowserAuth.session.name,
+    id: userInfo.userId,
+    name: userInfo.userName,
   };
-
-  // OVERRIDE: If Admin, allow fetching for another user
-  if (mediaBrowserAuth.session.isAdmin && parsed.targetUserId) {
+  if (userInfo.isAdmin && parsed.targetUserId) {
     targetUser = { id: parsed.targetUserId, name: null };
   }
 
@@ -491,7 +451,7 @@ export async function POST(request: NextRequest) {
   }
 
   const auth = await authenticateByName({
-    serverUrl: server.url,
+    serverUrl: getInternalUrl(server),
     username,
     password,
   });

--- a/apps/nextjs-app/app/api/watchlists/promoted/route.ts
+++ b/apps/nextjs-app/app/api/watchlists/promoted/route.ts
@@ -1,8 +1,5 @@
 import type { NextRequest } from "next/server";
-import {
-  authenticateMediaBrowser,
-  validateJellyfinToken,
-} from "@/lib/api-auth";
+import { authenticateMediaBrowserForServer } from "@/lib/api-auth";
 import {
   hasServerIdentifier,
   parseServerIdentifier,
@@ -74,45 +71,17 @@ export async function GET(request: NextRequest) {
     return jsonResponse({ error: "Server not found" }, 404);
   }
 
-  // Authenticate via MediaBrowser token
-  const mediaBrowserAuth = await authenticateMediaBrowser(request);
-  if (!mediaBrowserAuth) {
+  // Authenticate the MediaBrowser token against the requested server.
+  const userInfo = await authenticateMediaBrowserForServer({ request, server });
+  if (!userInfo) {
     return jsonResponse(
       {
         error: "Unauthorized",
         message:
-          'Valid Jellyfin token required. Use Authorization: MediaBrowser Token="..." header.',
+          'Valid Jellyfin token required for the requested server. Use Authorization: MediaBrowser Token="..." header.',
       },
       401,
     );
-  }
-
-  // Verify the authenticated server matches the requested server
-  if (mediaBrowserAuth.server.id !== server.id) {
-    const authHeader = request.headers.get("authorization");
-    const tokenMatch = authHeader?.match(/Token="([^"]*)"/i);
-    const token = tokenMatch?.[1];
-
-    if (token) {
-      const userInfo = await validateJellyfinToken(server.url, token);
-      if (!userInfo) {
-        return jsonResponse(
-          {
-            error: "Unauthorized",
-            message: "Token is not valid for the requested server.",
-          },
-          401,
-        );
-      }
-    } else {
-      return jsonResponse(
-        {
-          error: "Unauthorized",
-          message: "Token is not valid for the requested server.",
-        },
-        401,
-      );
-    }
   }
 
   const format = searchParams.get("format") || "full";

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -6,18 +6,15 @@ import type { Server } from "@streamystats/database";
 import { db, servers, users } from "@streamystats/database";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { jellyfinHeaders } from "./jellyfin-auth";
+import {
+  isTransientJellyfinStatus,
+  isValidJellyfinApiKey,
+  jellyfinHeaders,
+  SYSTEM_API_KEY_USER_ID,
+  SYSTEM_API_KEY_USER_NAME,
+} from "./jellyfin-auth";
 import { getInternalUrl } from "./server-url";
 import { getSession, type SessionUser } from "./session";
-
-/**
- * Identity surfaced when a request authenticates with a Jellyfin server
- * API key rather than a user access token. Centralised so the
- * MediaBrowser path here and `getUserFromEmbyToken` in `jellyfin-auth.ts`
- * stay in sync.
- */
-const SYSTEM_API_KEY_USER_ID = "system-api-key";
-const SYSTEM_API_KEY_USER_NAME = "System API Key";
 
 /**
  * Parse MediaBrowser authorization header
@@ -59,14 +56,13 @@ function parseMediaBrowserHeader(authHeader: string): {
  *
  * Accepts both Jellyfin user access tokens (returned by
  * `/Users/AuthenticateByName`) and Jellyfin server API keys. User
- * tokens are validated via `/Users/Me`. A server API key has no user
- * context, so `/Users/Me` rejects it (the exact status varies by
- * Jellyfin version); any non-OK response therefore falls back to a
- * `/System/Info` check and, on success, surfaces the caller as the
- * admin "system-api-key" pseudo-user — matching the pattern already
- * used by `getUserFromEmbyToken` in `jellyfin-auth.ts`. A valid user
- * token always returns 200 here, so the fallback never runs for real
- * users.
+ * tokens are validated via `/Users/Me` (200). A server API key has no
+ * user context, so `/Users/Me` rejects it (400 on current Jellyfin, 401
+ * on older versions); any non-transient failure therefore probes
+ * `/System/Info` and, on success, surfaces the caller as the admin
+ * "system-api-key" pseudo-user. Transient failures (429/5xx) and network
+ * errors return null so the caller can retry rather than guessing.
+ * Mirrors `getUserFromEmbyToken` in `jellyfin-auth.ts`.
  */
 export async function validateJellyfinToken(
   serverUrl: string,
@@ -88,30 +84,10 @@ export async function validateJellyfinToken(
       };
     }
 
-    // Any non-OK response means this is not a usable user access token.
-    // It may be a server API key (no user context) — validate it as one.
-    return await validateAsApiKey(serverUrl, token);
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      return null;
-    }
-    // A network error on /Users/Me may still leave /System/Info
-    // reachable for a valid API key; try the fallback before failing.
-    return await validateAsApiKey(serverUrl, token);
-  }
-}
-
-async function validateAsApiKey(
-  serverUrl: string,
-  token: string,
-): Promise<{ userId: string; userName: string; isAdmin: boolean } | null> {
-  try {
-    const sysRes = await fetch(`${serverUrl}/System/Info`, {
-      method: "GET",
-      headers: jellyfinHeaders(token),
-      signal: AbortSignal.timeout(5000),
-    });
-    if (sysRes.ok) {
+    if (
+      !isTransientJellyfinStatus(response.status) &&
+      (await isValidJellyfinApiKey(serverUrl, token))
+    ) {
       return {
         userId: SYSTEM_API_KEY_USER_ID,
         userName: SYSTEM_API_KEY_USER_NAME,
@@ -169,6 +145,44 @@ export async function authenticateMediaBrowser(
   }
 
   return null;
+}
+
+/**
+ * Authenticate a MediaBrowser-token request that targets a specific server
+ * resolved from query params (the public, server-scoped API routes). The
+ * token is validated against its own server via `authenticateMediaBrowser`;
+ * if the request targets a different server, the token is re-validated
+ * against that one (a user token or API key may be valid for several).
+ * Returns the caller identity, or null when no valid token is present for
+ * the requested server.
+ */
+export async function authenticateMediaBrowserForServer({
+  request,
+  server,
+}: {
+  request: NextRequest;
+  server: Server;
+}): Promise<{ userId: string; userName: string; isAdmin: boolean } | null> {
+  const mediaBrowserAuth = await authenticateMediaBrowser(request);
+  if (!mediaBrowserAuth) {
+    return null;
+  }
+
+  if (mediaBrowserAuth.server.id === server.id) {
+    return {
+      userId: mediaBrowserAuth.session.id,
+      userName: mediaBrowserAuth.session.name,
+      isAdmin: mediaBrowserAuth.session.isAdmin,
+    };
+  }
+
+  const parsed = parseMediaBrowserHeader(
+    request.headers.get("authorization") ?? "",
+  );
+  if (!parsed?.token) {
+    return null;
+  }
+  return await validateJellyfinToken(getInternalUrl(server), parsed.token);
 }
 
 /**

--- a/apps/nextjs-app/lib/jellyfin-auth.test.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getUserFromEmbyToken,
+  isTransientJellyfinStatus,
+} from "./jellyfin-auth";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Mock fetch that returns a configured status per Jellyfin endpoint and
+ * records which endpoints were hit, so tests can assert the fallback was
+ * (or was not) attempted.
+ */
+function mockJellyfin(opts: {
+  usersMe: { status: number; body?: unknown };
+  systemInfo?: { status: number };
+}) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/Users/Me")) {
+      calls.push("/Users/Me");
+      return jsonResponse(opts.usersMe.body ?? {}, opts.usersMe.status);
+    }
+    if (url.includes("/System/Info")) {
+      calls.push("/System/Info");
+      return jsonResponse({ Id: "sys-1" }, opts.systemInfo?.status ?? 500);
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("isTransientJellyfinStatus", () => {
+  test("429 and 5xx are transient", () => {
+    expect(isTransientJellyfinStatus(429)).toBe(true);
+    expect(isTransientJellyfinStatus(500)).toBe(true);
+    expect(isTransientJellyfinStatus(503)).toBe(true);
+  });
+
+  test("4xx (except 429) are not transient", () => {
+    expect(isTransientJellyfinStatus(400)).toBe(false);
+    expect(isTransientJellyfinStatus(401)).toBe(false);
+    expect(isTransientJellyfinStatus(403)).toBe(false);
+    expect(isTransientJellyfinStatus(404)).toBe(false);
+  });
+});
+
+describe("getUserFromEmbyToken", () => {
+  test("user access token: returns identity from /Users/Me", async () => {
+    mockJellyfin({
+      usersMe: {
+        status: 200,
+        body: {
+          Id: "user-1",
+          Name: "Alice",
+          Policy: { IsAdministrator: true },
+        },
+      },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "user-token",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user: { id: "user-1", name: "Alice", isAdmin: true },
+    });
+  });
+
+  // Regression guard: a Jellyfin server API key gets 400 (not 401) from
+  // /Users/Me. The fallback must still fire and surface the admin pseudo-user.
+  test("server API key: 400 from /Users/Me falls back to /System/Info", async () => {
+    const calls = mockJellyfin({
+      usersMe: { status: 400 },
+      systemInfo: { status: 200 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "api-key",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user: { id: "system-api-key", name: "System API Key", isAdmin: true },
+    });
+    expect(calls).toEqual(["/Users/Me", "/System/Info"]);
+  });
+
+  test("invalid token: 401 from both endpoints rejects", async () => {
+    mockJellyfin({
+      usersMe: { status: 401 },
+      systemInfo: { status: 401 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "bad-token",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Invalid Authorization header",
+    });
+  });
+
+  // Transient failures must NOT probe /System/Info — they stay retryable.
+  test("transient 503 from /Users/Me does not attempt key validation", async () => {
+    const calls = mockJellyfin({
+      usersMe: { status: 503 },
+      systemInfo: { status: 200 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "any-token",
+    });
+
+    expect(result).toEqual({ ok: false, error: "Jellyfin returned 503" });
+    expect(calls).toEqual(["/Users/Me"]);
+  });
+
+  test("400 from /Users/Me but invalid key: /System/Info 401 rejects", async () => {
+    mockJellyfin({
+      usersMe: { status: 400 },
+      systemInfo: { status: 401 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "revoked-key",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -43,6 +43,15 @@ export type JellyfinAuthUser = {
   isAdmin: boolean;
 };
 
+/**
+ * Identity surfaced when a request authenticates with a Jellyfin server
+ * API key rather than a user access token. Shared by both auth paths
+ * (`getUserFromEmbyToken` here and `validateJellyfinToken` in
+ * `api-auth.ts`) so they stay in sync.
+ */
+export const SYSTEM_API_KEY_USER_ID = "system-api-key";
+export const SYSTEM_API_KEY_USER_NAME = "System API Key";
+
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
@@ -51,6 +60,45 @@ function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * A failure that is the server's fault and likely to resolve on retry,
+ * as opposed to a definitive rejection of the request/token. Used to
+ * decide whether a non-OK `/Users/Me` is worth probing as an API key:
+ * a transient failure should stay retryable rather than trigger a guess.
+ */
+export function isTransientJellyfinStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Returns true when `token` is accepted by `/System/Info` (200), false on
+ * any non-OK response or network error.
+ *
+ * IMPORTANT: this is NOT an API-key-only check. `/System/Info` uses the
+ * `FirstTimeSetupOrIgnoreParentalControl` policy, which any non-guest
+ * principal satisfies — admins, server API keys (always Administrator),
+ * AND regular users. It is therefore only safe to treat a `true` result
+ * as "this is an admin API key" when the caller has already confirmed the
+ * token is NOT a usable user access token (i.e. `/Users/Me` returned a
+ * non-OK status first). A real user token returns 200 from `/Users/Me`
+ * and must be resolved there, before this probe is reached.
+ */
+export async function isValidJellyfinApiKey(
+  serverUrl: string,
+  token: string,
+): Promise<boolean> {
+  try {
+    const sysRes = await fetch(`${normalizeBaseUrl(serverUrl)}/System/Info`, {
+      method: "GET",
+      headers: jellyfinHeaders(token.trim()),
+      signal: AbortSignal.timeout(5000),
+    });
+    return sysRes.ok;
+  } catch {
+    return false;
+  }
 }
 
 export async function getUserFromEmbyToken(args: {
@@ -71,6 +119,24 @@ export async function getUserFromEmbyToken(args: {
     });
 
     if (!res.ok) {
+      // A user access token always returns 200 above. A non-OK status
+      // means this isn't a usable user token — but a server API key has
+      // no user context and is rejected here (400 on current Jellyfin,
+      // 401 on older versions). Probe it as an API key, unless the
+      // failure is transient (429/5xx), which should stay retryable.
+      if (
+        !isTransientJellyfinStatus(res.status) &&
+        (await isValidJellyfinApiKey(serverUrl, token))
+      ) {
+        return {
+          ok: true,
+          user: {
+            id: SYSTEM_API_KEY_USER_ID,
+            name: SYSTEM_API_KEY_USER_NAME,
+            isAdmin: true,
+          },
+        };
+      }
       if (res.status === 401) {
         return { ok: false, error: "Invalid Authorization header" };
       }
@@ -81,9 +147,6 @@ export async function getUserFromEmbyToken(args: {
     const id = asNonEmptyString(json.Id);
     if (!id) return { ok: false, error: "Jellyfin did not return a user id" };
     const name = asNonEmptyString(json.Name);
-
-    // API Keys don't return Policy in Users/Me usually, but if it's a user token it might.
-    // However, if we are here, it's a User Token.
     const isAdmin = json.Policy?.IsAdministrator ?? false;
 
     return { ok: true, user: { id, name, isAdmin } };
@@ -91,34 +154,8 @@ export async function getUserFromEmbyToken(args: {
     if (error instanceof Error && error.name === "AbortError") {
       return { ok: false, error: "Jellyfin request timed out" };
     }
-
-    // If /Users/Me failed, it might be an API Key.
-    // Try /System/Info to validate if it's a valid API Key.
-    try {
-      const sysRes = await fetch(
-        `${normalizeBaseUrl(args.serverUrl)}/System/Info`,
-        {
-          method: "GET",
-          headers: jellyfinHeaders(args.token.trim()),
-          signal: AbortSignal.timeout(5000),
-        },
-      );
-
-      if (sysRes.ok) {
-        // It is a valid API Key (Admin)
-        return {
-          ok: true,
-          user: {
-            id: "system-api-key",
-            name: "System API Key",
-            isAdmin: true,
-          },
-        };
-      }
-    } catch {
-      // Ignore error from System/Info and return original error
-    }
-
+    // Network error: `/System/Info` is unreachable too, so don't probe —
+    // surface the error and let the caller retry.
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Jellyfin request failed",


### PR DESCRIPTION
Follow-up to #515.

## What
- Recognize a Jellyfin **server API key** on the MediaBrowser auth path. `/Users/Me` rejects an API key with **400** (not 401 — verified against Jellyfin 10.11), so `validateJellyfinToken` and `getUserFromEmbyToken` now probe `/System/Info` on any **non-transient** failure and surface the admin `system-api-key` pseudo-user. Transient failures (429/5xx) and network errors return null so the caller can retry.
- Extract shared `isValidJellyfinApiKey` + `isTransientJellyfinStatus` so both auth paths behave identically.
- Refactor `/api/recommendations` and `/api/watchlists/promoted` onto a shared `authenticateMediaBrowserForServer` helper and use `getInternalUrl(server)` for server-to-server calls instead of raw `server.url`.

## Why
`/System/Info` is the authoritative check for an API key (a valid user token resolves at `/Users/Me` 200 and never reaches the probe), so gating strictly on 401 would reject valid keys that return 400. Unblocks server-to-server clients that only hold a Jellyfin API key (e.g. Maintainerr).

## Summary by Sourcery

Authenticate MediaBrowser API routes against Jellyfin server API keys and user tokens consistently and robustly across endpoints.

New Features:
- Support Jellyfin server API keys on MediaBrowser-authenticated routes by surfacing a shared admin pseudo-user identity when validated via /System/Info.

Bug Fixes:
- Treat non-401 failures (such as 400) from /Users/Me as potential server API key authentication for Jellyfin, avoiding false rejections of valid keys.
- Avoid probing Jellyfin /System/Info on transient /Users/Me failures so callers can safely retry instead of misclassifying tokens.

Enhancements:
- Share Jellyfin API key validation and transient status handling between MediaBrowser and Emby-style auth paths to keep behavior aligned.
- Introduce a helper to authenticate MediaBrowser tokens for a specific server and reuse it in recommendations and promoted watchlist routes.
- Use internal server URLs for server-to-server Jellyfin authentication calls instead of the public server URL.

Tests:
- Add unit tests for Jellyfin auth behavior, including transient status detection and API key vs user token handling on /Users/Me and /System/Info fallbacks.