### PR TITLE
fix: authenticate Jellyfin server API keys for MediaBrowser API routes

### DIFF
--- a/apps/nextjs-app/app/api/recommendations/route.ts
+++ b/apps/nextjs-app/app/api/recommendations/route.ts
@@ -1,9 +1,6 @@
 import type { Server } from "@streamystats/database";
 import type { NextRequest } from "next/server";
-import {
-  authenticateMediaBrowser,
-  validateJellyfinToken,
-} from "@/lib/api-auth";
+import { authenticateMediaBrowserForServer } from "@/lib/api-auth";
 import {
   hasServerIdentifier,
   parseServerIdentifier,
@@ -19,6 +16,7 @@ import {
   type RecommendationItem,
 } from "@/lib/db/similar-statistics";
 import { authenticateByName } from "@/lib/jellyfin-auth";
+import { getInternalUrl } from "@/lib/server-url";
 
 type RecommendationType = "Movie" | "Series" | "all";
 type RangePreset = "7d" | "30d" | "90d" | "thisMonth" | "all";
@@ -381,63 +379,25 @@ export async function GET(request: NextRequest) {
     return jsonResponse({ error: "Server not found" }, 404);
   }
 
-  // Try MediaBrowser auth (Authorization: MediaBrowser Token="...")
-  const mediaBrowserAuth = await authenticateMediaBrowser(request);
-  if (!mediaBrowserAuth) {
+  // Authenticate the MediaBrowser token against the requested server.
+  const userInfo = await authenticateMediaBrowserForServer({ request, server });
+  if (!userInfo) {
     return jsonResponse(
       {
         error: "Unauthorized",
         message:
-          'Valid Jellyfin token required. Use Authorization: MediaBrowser Token="..." header.',
+          'Valid Jellyfin token required for the requested server. Use Authorization: MediaBrowser Token="..." header.',
       },
       401,
     );
   }
 
-  // Verify the authenticated server matches the requested server
-  if (mediaBrowserAuth.server.id !== server.id) {
-    // Token is valid but for a different server - try validating against requested server
-    const authHeader = request.headers.get("authorization");
-    const tokenMatch = authHeader?.match(/Token="([^"]*)"/i);
-    const token = tokenMatch?.[1];
-
-    if (token) {
-      const userInfo = await validateJellyfinToken(server.url, token);
-      if (userInfo) {
-        let targetUser: ApiUser = {
-          id: userInfo.userId,
-          name: userInfo.userName,
-        };
-        if (userInfo.isAdmin && parsed.targetUserId) {
-          targetUser = { id: parsed.targetUserId, name: null };
-        }
-        const payload = await buildRecommendationsResponse({
-          server,
-          user: targetUser,
-          params: parsed.params,
-          timeWindow: parsed.timeWindow,
-        });
-        return jsonResponse(payload, 200);
-      }
-    }
-
-    return jsonResponse(
-      {
-        error: "Unauthorized",
-        message: "Token is not valid for the requested server.",
-      },
-      401,
-    );
-  }
-
-  // DEFAULT: Use the authenticated user
+  // DEFAULT: the authenticated user. OVERRIDE: an admin may target another.
   let targetUser: ApiUser = {
-    id: mediaBrowserAuth.session.id,
-    name: mediaBrowserAuth.session.name,
+    id: userInfo.userId,
+    name: userInfo.userName,
   };
-
-  // OVERRIDE: If Admin, allow fetching for another user
-  if (mediaBrowserAuth.session.isAdmin && parsed.targetUserId) {
+  if (userInfo.isAdmin && parsed.targetUserId) {
     targetUser = { id: parsed.targetUserId, name: null };
   }
 
@@ -491,7 +451,7 @@ export async function POST(request: NextRequest) {
   }
 
   const auth = await authenticateByName({
-    serverUrl: server.url,
+    serverUrl: getInternalUrl(server),
     username,
     password,
   });

--- a/apps/nextjs-app/app/api/watchlists/promoted/route.ts
+++ b/apps/nextjs-app/app/api/watchlists/promoted/route.ts
@@ -1,8 +1,5 @@
 import type { NextRequest } from "next/server";
-import {
-  authenticateMediaBrowser,
-  validateJellyfinToken,
-} from "@/lib/api-auth";
+import { authenticateMediaBrowserForServer } from "@/lib/api-auth";
 import {
   hasServerIdentifier,
   parseServerIdentifier,
@@ -74,45 +71,17 @@ export async function GET(request: NextRequest) {
     return jsonResponse({ error: "Server not found" }, 404);
   }
 
-  // Authenticate via MediaBrowser token
-  const mediaBrowserAuth = await authenticateMediaBrowser(request);
-  if (!mediaBrowserAuth) {
+  // Authenticate the MediaBrowser token against the requested server.
+  const userInfo = await authenticateMediaBrowserForServer({ request, server });
+  if (!userInfo) {
     return jsonResponse(
       {
         error: "Unauthorized",
         message:
-          'Valid Jellyfin token required. Use Authorization: MediaBrowser Token="..." header.',
+          'Valid Jellyfin token required for the requested server. Use Authorization: MediaBrowser Token="..." header.',
       },
       401,
     );
-  }
-
-  // Verify the authenticated server matches the requested server
-  if (mediaBrowserAuth.server.id !== server.id) {
-    const authHeader = request.headers.get("authorization");
-    const tokenMatch = authHeader?.match(/Token="([^"]*)"/i);
-    const token = tokenMatch?.[1];
-
-    if (token) {
-      const userInfo = await validateJellyfinToken(server.url, token);
-      if (!userInfo) {
-        return jsonResponse(
-          {
-            error: "Unauthorized",
-            message: "Token is not valid for the requested server.",
-          },
-          401,
-        );
-      }
-    } else {
-      return jsonResponse(
-        {
-          error: "Unauthorized",
-          message: "Token is not valid for the requested server.",
-        },
-        401,
-      );
-    }
   }
 
   const format = searchParams.get("format") || "full";

--- a/apps/nextjs-app/lib/api-auth.ts
+++ b/apps/nextjs-app/lib/api-auth.ts
@@ -6,18 +6,17 @@ import type { Server } from "@streamystats/database";
 import { db, servers, users } from "@streamystats/database";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { jellyfinHeaders } from "./jellyfin-auth";
+import {
+  isTransientJellyfinStatus,
+  isValidJellyfinApiKey,
+  JELLYFIN_REQUEST_TIMEOUT_MS,
+  jellyfinHeaders,
+  normalizeBaseUrl,
+  SYSTEM_API_KEY_USER_ID,
+  SYSTEM_API_KEY_USER_NAME,
+} from "./jellyfin-auth";
 import { getInternalUrl } from "./server-url";
 import { getSession, type SessionUser } from "./session";
-
-/**
- * Identity surfaced when a request authenticates with a Jellyfin server
- * API key rather than a user access token. Centralised so the
- * MediaBrowser path here and `getUserFromEmbyToken` in `jellyfin-auth.ts`
- * stay in sync.
- */
-const SYSTEM_API_KEY_USER_ID = "system-api-key";
-const SYSTEM_API_KEY_USER_NAME = "System API Key";
 
 /**
  * Parse MediaBrowser authorization header
@@ -59,24 +58,24 @@ function parseMediaBrowserHeader(authHeader: string): {
  *
  * Accepts both Jellyfin user access tokens (returned by
  * `/Users/AuthenticateByName`) and Jellyfin server API keys. User
- * tokens are validated via `/Users/Me`. A server API key has no user
- * context, so `/Users/Me` rejects it (the exact status varies by
- * Jellyfin version); any non-OK response therefore falls back to a
- * `/System/Info` check and, on success, surfaces the caller as the
- * admin "system-api-key" pseudo-user — matching the pattern already
- * used by `getUserFromEmbyToken` in `jellyfin-auth.ts`. A valid user
- * token always returns 200 here, so the fallback never runs for real
- * users.
+ * tokens are validated via `/Users/Me` (200). A server API key has no
+ * user context, so `/Users/Me` rejects it (400 on current Jellyfin, 401
+ * on older versions); any non-transient failure therefore probes
+ * `/System/Info` and, on success, surfaces the caller as the admin
+ * "system-api-key" pseudo-user. Transient failures (429/5xx) and network
+ * errors return null so the caller can retry rather than guessing.
+ * Mirrors `getUserFromEmbyToken` in `jellyfin-auth.ts`.
  */
 export async function validateJellyfinToken(
   serverUrl: string,
   token: string,
 ): Promise<{ userId: string; userName: string; isAdmin: boolean } | null> {
+  const baseUrl = normalizeBaseUrl(serverUrl);
   try {
-    const response = await fetch(`${serverUrl}/Users/Me`, {
+    const response = await fetch(`${baseUrl}/Users/Me`, {
       method: "GET",
       headers: jellyfinHeaders(token),
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
     });
 
     if (response.ok) {
@@ -88,30 +87,10 @@ export async function validateJellyfinToken(
       };
     }
 
-    // Any non-OK response means this is not a usable user access token.
-    // It may be a server API key (no user context) — validate it as one.
-    return await validateAsApiKey(serverUrl, token);
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      return null;
-    }
-    // A network error on /Users/Me may still leave /System/Info
-    // reachable for a valid API key; try the fallback before failing.
-    return await validateAsApiKey(serverUrl, token);
-  }
-}
-
-async function validateAsApiKey(
-  serverUrl: string,
-  token: string,
-): Promise<{ userId: string; userName: string; isAdmin: boolean } | null> {
-  try {
-    const sysRes = await fetch(`${serverUrl}/System/Info`, {
-      method: "GET",
-      headers: jellyfinHeaders(token),
-      signal: AbortSignal.timeout(5000),
-    });
-    if (sysRes.ok) {
+    if (
+      !isTransientJellyfinStatus(response.status) &&
+      (await isValidJellyfinApiKey(baseUrl, token))
+    ) {
       return {
         userId: SYSTEM_API_KEY_USER_ID,
         userName: SYSTEM_API_KEY_USER_NAME,
@@ -131,7 +110,7 @@ async function validateAsApiKey(
  */
 export async function authenticateMediaBrowser(
   request: NextRequest,
-): Promise<{ session: SessionUser; server: Server } | null> {
+): Promise<{ session: SessionUser; server: Server; token: string } | null> {
   const authHeader = request.headers.get("authorization");
   if (!authHeader) {
     return null;
@@ -141,15 +120,13 @@ export async function authenticateMediaBrowser(
   if (!parsed?.token) {
     return null;
   }
+  const token = parsed.token;
 
   // Get all servers and try to validate against each
   const allServers = await db.select().from(servers);
 
   for (const server of allServers) {
-    const userInfo = await validateJellyfinToken(
-      getInternalUrl(server),
-      parsed.token,
-    );
+    const userInfo = await validateJellyfinToken(getInternalUrl(server), token);
     if (userInfo) {
       // Check if this user exists in our database for this server
       const dbUser = await db.query.users.findFirst({
@@ -164,11 +141,41 @@ export async function authenticateMediaBrowser(
           isAdmin: userInfo.isAdmin || dbUser?.isAdministrator || false,
         },
         server,
+        token,
       };
     }
   }
 
   return null;
+}
+
+// Authenticates a MediaBrowser token against a specific (query-resolved) server,
+// re-validating against that server when it differs from the token's own.
+export async function authenticateMediaBrowserForServer({
+  request,
+  server,
+}: {
+  request: NextRequest;
+  server: Server;
+}): Promise<{ userId: string; userName: string; isAdmin: boolean } | null> {
+  const mediaBrowserAuth = await authenticateMediaBrowser(request);
+  if (!mediaBrowserAuth) {
+    return null;
+  }
+
+  if (mediaBrowserAuth.server.id === server.id) {
+    return {
+      userId: mediaBrowserAuth.session.id,
+      userName: mediaBrowserAuth.session.name,
+      isAdmin: mediaBrowserAuth.session.isAdmin,
+    };
+  }
+
+  // Different server: re-check, reusing the token instead of re-parsing the header.
+  return await validateJellyfinToken(
+    getInternalUrl(server),
+    mediaBrowserAuth.token,
+  );
 }
 
 /**

--- a/apps/nextjs-app/lib/jellyfin-auth.test.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  getUserFromEmbyToken,
+  isTransientJellyfinStatus,
+} from "./jellyfin-auth";
+
+// Scope the fetch mock to each test via spyOn + mockRestore, so the global
+// is always restored afterwards and tests can't interfere with one another.
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+beforeEach(() => {
+  fetchSpy = spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Install a per-test fetch mock that returns a configured status per Jellyfin
+ * endpoint and records which endpoints were hit, so tests can assert the
+ * fallback was (or was not) attempted.
+ */
+function mockJellyfin(opts: {
+  usersMe: { status: number; body?: unknown };
+  systemInfo?: { status: number };
+}) {
+  const calls: string[] = [];
+  fetchSpy.mockImplementation((async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/Users/Me")) {
+      calls.push("/Users/Me");
+      return jsonResponse(opts.usersMe.body ?? {}, opts.usersMe.status);
+    }
+    if (url.includes("/System/Info")) {
+      calls.push("/System/Info");
+      return jsonResponse({ Id: "sys-1" }, opts.systemInfo?.status ?? 500);
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch);
+  return calls;
+}
+
+describe("isTransientJellyfinStatus", () => {
+  test("429 and 5xx are transient", () => {
+    expect(isTransientJellyfinStatus(429)).toBe(true);
+    expect(isTransientJellyfinStatus(500)).toBe(true);
+    expect(isTransientJellyfinStatus(503)).toBe(true);
+  });
+
+  test("4xx (except 429) are not transient", () => {
+    expect(isTransientJellyfinStatus(400)).toBe(false);
+    expect(isTransientJellyfinStatus(401)).toBe(false);
+    expect(isTransientJellyfinStatus(403)).toBe(false);
+    expect(isTransientJellyfinStatus(404)).toBe(false);
+  });
+});
+
+describe("getUserFromEmbyToken", () => {
+  test("user access token: returns identity from /Users/Me", async () => {
+    mockJellyfin({
+      usersMe: {
+        status: 200,
+        body: {
+          Id: "user-1",
+          Name: "Alice",
+          Policy: { IsAdministrator: true },
+        },
+      },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "user-token",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user: { id: "user-1", name: "Alice", isAdmin: true },
+    });
+  });
+
+  // Regression guard: a Jellyfin server API key gets 400 (not 401) from
+  // /Users/Me. The fallback must still fire and surface the admin pseudo-user.
+  test("server API key: 400 from /Users/Me falls back to /System/Info", async () => {
+    const calls = mockJellyfin({
+      usersMe: { status: 400 },
+      systemInfo: { status: 200 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "api-key",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user: { id: "system-api-key", name: "System API Key", isAdmin: true },
+    });
+    expect(calls).toEqual(["/Users/Me", "/System/Info"]);
+  });
+
+  test("invalid token: 401 from both endpoints rejects", async () => {
+    mockJellyfin({
+      usersMe: { status: 401 },
+      systemInfo: { status: 401 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "bad-token",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Invalid Authorization header",
+    });
+  });
+
+  // Transient failures must NOT probe /System/Info — they stay retryable.
+  test("transient 503 from /Users/Me does not attempt key validation", async () => {
+    const calls = mockJellyfin({
+      usersMe: { status: 503 },
+      systemInfo: { status: 200 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "any-token",
+    });
+
+    expect(result).toEqual({ ok: false, error: "Jellyfin returned 503" });
+    expect(calls).toEqual(["/Users/Me"]);
+  });
+
+  test("400 from /Users/Me but invalid key: /System/Info 401 rejects", async () => {
+    mockJellyfin({
+      usersMe: { status: 400 },
+      systemInfo: { status: 401 },
+    });
+
+    const result = await getUserFromEmbyToken({
+      serverUrl: "http://jf.local",
+      token: "revoked-key",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/nextjs-app/lib/jellyfin-auth.ts
+++ b/apps/nextjs-app/lib/jellyfin-auth.ts
@@ -43,7 +43,13 @@ export type JellyfinAuthUser = {
   isAdmin: boolean;
 };
 
-function normalizeBaseUrl(baseUrl: string): string {
+// Pseudo-user surfaced when a request authenticates with a server API key.
+export const SYSTEM_API_KEY_USER_ID = "system-api-key";
+export const SYSTEM_API_KEY_USER_NAME = "System API Key";
+
+export const JELLYFIN_REQUEST_TIMEOUT_MS = 5000;
+
+export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
@@ -51,6 +57,28 @@ function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+export function isTransientJellyfinStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+// NOTE: /System/Info accepts ANY non-guest token (incl. regular users), not just
+// API keys — only treat `true` as "admin API key" after /Users/Me has rejected it.
+export async function isValidJellyfinApiKey(
+  serverUrl: string,
+  token: string,
+): Promise<boolean> {
+  try {
+    const sysRes = await fetch(`${normalizeBaseUrl(serverUrl)}/System/Info`, {
+      method: "GET",
+      headers: jellyfinHeaders(token.trim()),
+      signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
+    });
+    return sysRes.ok;
+  } catch {
+    return false;
+  }
 }
 
 export async function getUserFromEmbyToken(args: {
@@ -67,10 +95,24 @@ export async function getUserFromEmbyToken(args: {
     const res = await fetch(`${serverUrl}/Users/Me`, {
       method: "GET",
       headers: jellyfinHeaders(token),
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(JELLYFIN_REQUEST_TIMEOUT_MS),
     });
 
     if (!res.ok) {
+      // Server API keys have no user context → 400 here (not 401); probe as a key unless transient.
+      if (
+        !isTransientJellyfinStatus(res.status) &&
+        (await isValidJellyfinApiKey(serverUrl, token))
+      ) {
+        return {
+          ok: true,
+          user: {
+            id: SYSTEM_API_KEY_USER_ID,
+            name: SYSTEM_API_KEY_USER_NAME,
+            isAdmin: true,
+          },
+        };
+      }
       if (res.status === 401) {
         return { ok: false, error: "Invalid Authorization header" };
       }
@@ -81,9 +123,6 @@ export async function getUserFromEmbyToken(args: {
     const id = asNonEmptyString(json.Id);
     if (!id) return { ok: false, error: "Jellyfin did not return a user id" };
     const name = asNonEmptyString(json.Name);
-
-    // API Keys don't return Policy in Users/Me usually, but if it's a user token it might.
-    // However, if we are here, it's a User Token.
     const isAdmin = json.Policy?.IsAdministrator ?? false;
 
     return { ok: true, user: { id, name, isAdmin } };
@@ -91,34 +130,7 @@ export async function getUserFromEmbyToken(args: {
     if (error instanceof Error && error.name === "AbortError") {
       return { ok: false, error: "Jellyfin request timed out" };
     }
-
-    // If /Users/Me failed, it might be an API Key.
-    // Try /System/Info to validate if it's a valid API Key.
-    try {
-      const sysRes = await fetch(
-        `${normalizeBaseUrl(args.serverUrl)}/System/Info`,
-        {
-          method: "GET",
-          headers: jellyfinHeaders(args.token.trim()),
-          signal: AbortSignal.timeout(5000),
-        },
-      );
-
-      if (sysRes.ok) {
-        // It is a valid API Key (Admin)
-        return {
-          ok: true,
-          user: {
-            id: "system-api-key",
-            name: "System API Key",
-            isAdmin: true,
-          },
-        };
-      }
-    } catch {
-      // Ignore error from System/Info and return original error
-    }
-
+    // Network error: don't probe /System/Info (also unreachable) — let the caller retry.
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Jellyfin request failed",


### PR DESCRIPTION
Follow-up to #515.

## What
- Recognize a Jellyfin **server API key** on the MediaBrowser auth path. `/Users/Me` rejects an API key with **400** (not 401 — verified against Jellyfin 10.11), so `validateJellyfinToken` and `getUserFromEmbyToken` now probe `/System/Info` on any **non-transient** failure and surface the admin `system-api-key` pseudo-user. Transient failures (429/5xx) and network errors return null so the caller can retry.
- Extract shared helpers (`isValidJellyfinApiKey`, `isTransientJellyfinStatus`, `JELLYFIN_REQUEST_TIMEOUT_MS`, `normalizeBaseUrl`) so both auth paths behave identically and base-URL normalization is consistent.
- Refactor `/api/recommendations` and `/api/watchlists/promoted` onto a shared `authenticateMediaBrowserForServer` helper (which reuses the token surfaced by `authenticateMediaBrowser` instead of re-parsing the header) and use `getInternalUrl(server)` for server-to-server calls instead of raw `server.url`.

## Why
`/System/Info` is the authoritative check for an API key (a valid user token resolves at `/Users/Me` 200 and never reaches the probe), so gating strictly on 401 would reject valid keys that return 400. Unblocks server-to-server clients that only hold a Jellyfin API key (e.g. Maintainerr).

## Summary by Sourcery

Authenticate Jellyfin MediaBrowser requests with both user tokens and server API keys while unifying auth behavior across routes and improving reliability.

New Features:
- Support Jellyfin server API keys for MediaBrowser-authenticated API routes by surfacing a shared system-api-key pseudo-user when validated via /System/Info.

Bug Fixes:
- Treat non-401 failures (e.g. 400) from /Users/Me as potential server API keys and avoid probing on transient or network errors to prevent incorrect rejections and allow safe retries.

Enhancements:
- Centralize Jellyfin auth helpers for base-URL normalization, transient status detection, request timeouts, and API-key probing so MediaBrowser and Emby-style auth share consistent behavior.
- Add an authenticateMediaBrowserForServer helper and refactor recommendations and promoted watchlists routes to rely on it and internal server URLs for server-scoped MediaBrowser authentication.

Tests:
- Add unit tests for Jellyfin auth behavior, including transient status detection and regression coverage for API-key vs user-token handling on /Users/Me and /System/Info.