### PR TITLE
feat: add per-item watch-location (country) endpoint

### DIFF
--- a/apps/nextjs-app/app/api/items/[itemId]/locations/route.ts
+++ b/apps/nextjs-app/app/api/items/[itemId]/locations/route.ts
@@ -1,0 +1,50 @@
+import type { NextRequest } from "next/server";
+import { requireApiKey } from "@/lib/api-auth";
+import { getItemLocations } from "@/lib/db/locations";
+import { getServerWithSecrets } from "@/lib/db/server";
+
+// GET /api/items/[itemId]/locations?serverId= — countries an item was watched
+// from. API-key auth, same as /api/get-item-details.
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ itemId: string }> },
+) {
+  const { itemId } = await params;
+  const serverIdParam = request.nextUrl.searchParams.get("serverId");
+
+  if (!itemId) {
+    return jsonResponse({ error: "itemId is required" }, 400);
+  }
+  if (!serverIdParam) {
+    return jsonResponse({ error: "serverId query parameter is required" }, 400);
+  }
+
+  const serverId = Number(serverIdParam);
+  if (!Number.isInteger(serverId)) {
+    return jsonResponse({ error: "serverId must be a number" }, 400);
+  }
+
+  const server = await getServerWithSecrets({ serverId });
+  if (!server) {
+    return jsonResponse({ error: "Server not found" }, 404);
+  }
+
+  const authError = await requireApiKey({ request, server });
+  if (authError) {
+    return authError;
+  }
+
+  const locations = await getItemLocations({
+    itemId,
+    serverId: server.id,
+  });
+
+  return jsonResponse(locations);
+}

--- a/apps/nextjs-app/lib/db/locations.ts
+++ b/apps/nextjs-app/lib/db/locations.ts
@@ -10,7 +10,19 @@ import {
   userFingerprints,
   users,
 } from "@streamystats/database";
-import { and, count, desc, eq, gte, lte, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  gte,
+  lte,
+  notInArray,
+  type SQL,
+  sql,
+} from "drizzle-orm";
+import { getExclusionSettings } from "./exclusions";
 
 export interface LocationPoint {
   latitude: number;
@@ -875,5 +887,75 @@ export async function getServerLocationStats(serverId: number): Promise<{
       anomaliesResult.map((a) => [a.severity, Number(a.count)]),
     ),
     isBackfillRunning,
+  };
+}
+
+export interface ItemCountryStat {
+  countryCode: string | null;
+  country: string | null;
+  playCount: number;
+  uniqueUsers: number;
+  lastWatched: string | null;
+}
+
+export interface ItemLocations {
+  itemId: string;
+  countries: ItemCountryStat[];
+  geolocatedPlayCount: number;
+  // Private/LAN IPs (no country); empty `countries` means "unknown", not "never watched".
+  localPlayCount: number;
+}
+
+// Per-item country aggregation from geolocated activity IPs, scoped to one
+// server and filtered by its user exclusions.
+export async function getItemLocations(args: {
+  itemId: string;
+  serverId: number;
+}): Promise<ItemLocations> {
+  const { itemId, serverId } = args;
+  const { excludedUserIds } = await getExclusionSettings(serverId);
+
+  const baseConditions: SQL[] = [
+    eq(activities.serverId, serverId),
+    eq(activities.itemId, itemId),
+  ];
+  if (excludedUserIds.length > 0) {
+    baseConditions.push(notInArray(activities.userId, excludedUserIds));
+  }
+
+  const [countryRows, localRow] = await Promise.all([
+    db
+      .select({
+        countryCode: activityLocations.countryCode,
+        country: activityLocations.country,
+        playCount: count(),
+        uniqueUsers: countDistinct(activities.userId),
+        lastWatched: sql<string | null>`MAX(${activities.date})`,
+      })
+      .from(activityLocations)
+      .innerJoin(activities, eq(activityLocations.activityId, activities.id))
+      .where(and(...baseConditions, eq(activityLocations.isPrivateIp, false)))
+      .groupBy(activityLocations.countryCode, activityLocations.country)
+      .orderBy(desc(count())),
+    db
+      .select({ playCount: count() })
+      .from(activityLocations)
+      .innerJoin(activities, eq(activityLocations.activityId, activities.id))
+      .where(and(...baseConditions, eq(activityLocations.isPrivateIp, true))),
+  ]);
+
+  const countries: ItemCountryStat[] = countryRows.map((r) => ({
+    countryCode: r.countryCode,
+    country: r.country,
+    playCount: Number(r.playCount),
+    uniqueUsers: Number(r.uniqueUsers),
+    lastWatched: r.lastWatched,
+  }));
+
+  return {
+    itemId,
+    countries,
+    geolocatedPlayCount: countries.reduce((sum, c) => sum + c.playCount, 0),
+    localPlayCount: Number(localRow[0]?.playCount ?? 0),
   };
 }


### PR DESCRIPTION
## What
Adds `GET /api/items/{itemId}/locations?serverId=` — the countries a media item was watched from, derived from geolocated activity IPs (`activityLocations`).

- Auth: `requireApiKey` (same as `/api/get-item-details`), so it works with a Jellyfin API key.
- Scoped to a single server; applies the server's user exclusions.
- Private/LAN IPs carry no country and are reported separately as `localPlayCount`, so callers can tell "watched locally" apart from "unknown".

Response:
```json
{
  "itemId": "…",
  "countries": [
    { "countryCode": "US", "country": "United States", "playCount": 2, "uniqueUsers": 1, "lastWatched": "…" }
  ],
  "geolocatedPlayCount": 2,
  "localPlayCount": 1
}
```

## Why
Streamystats already exposes rich per-item watch analytics via `/api/get-item-details`, but geo was the one signal with no endpoint. This unblocks geo-based rules in downstream clients (e.g. a Maintainerr "watched from country X" rule) — something Jellyfin's own API can't provide.

## Notes
- Geo comes from the client IP via geoip-lite; most home/LAN playback has a private IP and lands in `localPlayCount`, so an empty `countries` list means "unknown", not "never watched".
- No unit test added: the route mirrors the existing untested `get-item-details`/`viewers` handlers, and Bun's global `mock.module` bleeds across the existing `__tests__` files. Verified end-to-end against a live Jellyfin + Postgres instead.

## Summary by Sourcery

Add a new API endpoint to return per-item watch locations by country, including geolocated and local play counts, scoped to a specific server and respecting user exclusion settings.

New Features:
- Introduce database query utilities to aggregate per-item country watch statistics and split geolocated versus local playback counts.
- Expose a GET /api/items/{itemId}/locations endpoint secured by API key authentication to retrieve watch-location analytics for a given server item.