### PR TITLE
ci: build-only Docker images for fork PRs to avoid GHCR push denial

### DIFF
--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -13,6 +13,8 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+  # Fork PRs get a read-only token (can't push to GHCR or comment) → same-repo only.
+  IS_SAME_REPO_PR: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
   lint:
@@ -124,11 +126,12 @@ jobs:
             VERSION=pr-${{ steps.pr.outputs.number }}
             COMMIT_SHA=${{ github.sha }}
             BUILD_TIME=${{ github.event.pull_request.updated_at }}
-          push: true
+          push: ${{ env.IS_SAME_REPO_PR == 'true' }}
           tags: |
             ${{ env.IMAGE_NAMESPACE }}/${{ matrix.part }}:pr-${{ steps.pr.outputs.number }}
 
       - name: Run Trivy vulnerability scanner
+        if: ${{ env.IS_SAME_REPO_PR == 'true' }}
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE_NAMESPACE }}/${{ matrix.part }}:pr-${{ steps.pr.outputs.number }}
@@ -165,6 +168,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Add PR comment
+        if: ${{ env.IS_SAME_REPO_PR == 'true' }}
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Problem
`PR Docker Build & Push` fails on every PR from a fork. GitHub gives fork PRs a **read-only** `GITHUB_TOKEN` (the declared `permissions:` are ignored for forks), so:
- the build step's `push: true` to GHCR fails with `denied: installation not allowed to Write organization package`, and
- the summary job's `Add PR comment` step fails (`issues: write` is read-only too).

The image itself builds fine — only the push/comment are denied.

## Fix
Gate the registry/comment actions on same-repo PRs; fork PRs build-only (still validating the Dockerfile):

- `push:` → `${{ github.event.pull_request.head.repo.full_name == github.repository }}`
- Trivy scan → `if:` same condition (nothing is pushed to scan for forks)
- `Add PR comment` → `if:` same condition (needs `issues: write`)

Same-repo PRs are unchanged (build + push + scan + comment). Fork PRs now go green after building both images.

## Summary by Sourcery

CI:
- Conditionally push Docker images, run Trivy scans, and post PR comments only for same-repository pull requests to avoid permission errors on forked PRs.