### PR TITLE
feat(ai): people and character search tool

### DIFF
--- a/apps/nextjs-app/lib/ai/tools.ts
+++ b/apps/nextjs-app/lib/ai/tools.ts
@@ -474,11 +474,15 @@ export function createChatTools(serverId: number, userId: string) {
 
     findItemsByPerson: tool({
       description:
-        "Find movies or TV series connected to a person, such as an actor, director, writer, or producer. Use this for questions like 'movies with Ana de Armas', 'what is Pedro Pascal in?', or 'films directed by Christopher Nolan'. Actor credits are searched by default.",
+        "Find movies or TV series connected to one or more people, such as actors, directors, writers, or producers. Every requested person must be connected to each returned item. Use this for questions like 'movies with Ana de Armas', 'movies with Ana de Armas and Chris Evans', 'what is Pedro Pascal in?', or 'films directed by Christopher Nolan'. Actor credits are searched by default.",
       inputSchema: z.object({
-        personName: z
-          .string()
-          .describe("Name or partial name of the person to search for"),
+        personNames: z
+          .array(z.string())
+          .min(1)
+          .max(10)
+          .describe(
+            "Names or partial names of the people to search for. Returned items must match every person.",
+          ),
         creditType: z
           .enum(["Actor", "Director", "Writer", "Producer", "all"])
           .optional()
@@ -500,10 +504,10 @@ export function createChatTools(serverId: number, userId: string) {
           .default(20)
           .describe("Number of items to return"),
       }),
-      execute: async ({ personName, creditType, type, limit }) => {
+      execute: async ({ personNames, creditType, type, limit }) => {
         const results = await findItemsByPerson({
           serverId,
-          personName,
+          personNames,
           creditType,
           type,
           limit,
@@ -514,11 +518,13 @@ export function createChatTools(serverId: number, userId: string) {
             ...formatItem(item),
             matchedCredits: credits,
           })),
-          personName,
+          personNames,
           message:
             results.length > 0
-              ? `Found ${results.length} items connected to "${personName}"`
-              : `No items found for person "${personName}"`,
+              ? `Found ${results.length} items connected to ${personNames.join(
+                  " and ",
+                )}`
+              : `No items found connected to ${personNames.join(" and ")}`,
         };
       },
     }),

--- a/apps/nextjs-app/lib/ai/tools.ts
+++ b/apps/nextjs-app/lib/ai/tools.ts
@@ -23,6 +23,10 @@ import {
 import { z } from "zod";
 import { getHistoryByFilters } from "@/lib/db/history";
 import {
+  findItemsByCharacter,
+  findItemsByPerson,
+} from "@/lib/db/item-people-search";
+import {
   getSimilarItemsForItem,
   getSimilarStatistics,
 } from "@/lib/db/similar-statistics";
@@ -464,6 +468,100 @@ export function createChatTools(serverId: number, userId: string) {
             results.length > 0
               ? `Found ${results.length} items matching "${query}"`
               : `No items found matching "${query}"`,
+        };
+      },
+    }),
+
+    findItemsByPerson: tool({
+      description:
+        "Find movies or TV series connected to a person, such as an actor, director, writer, or producer. Use this for questions like 'movies with Ana de Armas', 'what is Pedro Pascal in?', or 'films directed by Christopher Nolan'. Actor credits are searched by default.",
+      inputSchema: z.object({
+        personName: z
+          .string()
+          .describe("Name or partial name of the person to search for"),
+        creditType: z
+          .enum(["Actor", "Director", "Writer", "Producer", "all"])
+          .optional()
+          .default("Actor")
+          .describe(
+            "Credit type to search. Use Actor for starring/with questions, a specific crew type when requested, or all for any connection.",
+          ),
+        type: z
+          .enum(["Movie", "Series", "all"])
+          .optional()
+          .default("all")
+          .describe("Filter by media type"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .default(20)
+          .describe("Number of items to return"),
+      }),
+      execute: async ({ personName, creditType, type, limit }) => {
+        const results = await findItemsByPerson({
+          serverId,
+          personName,
+          creditType,
+          type,
+          limit,
+        });
+
+        return {
+          items: results.map(({ item, credits }) => ({
+            ...formatItem(item),
+            matchedCredits: credits,
+          })),
+          personName,
+          message:
+            results.length > 0
+              ? `Found ${results.length} items connected to "${personName}"`
+              : `No items found for person "${personName}"`,
+        };
+      },
+    }),
+
+    findItemsByCharacter: tool({
+      description:
+        "Find the movie or TV series a fictional character appears in. Use this for questions like 'which TV show is Walter White from?', 'what movie has Tony Stark?', or 'where does Eleven appear?'. Returns the matching character roles and the actors who played them.",
+      inputSchema: z.object({
+        characterName: z
+          .string()
+          .describe("Name or partial name of the character to search for"),
+        type: z
+          .enum(["Movie", "Series", "all"])
+          .optional()
+          .default("all")
+          .describe("Filter by media type"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .default(20)
+          .describe("Number of items to return"),
+      }),
+      execute: async ({ characterName, type, limit }) => {
+        const results = await findItemsByCharacter({
+          serverId,
+          characterName,
+          type,
+          limit,
+        });
+
+        return {
+          items: results.map(({ item, credits }) => ({
+            ...formatItem(item),
+            matchedCredits: credits,
+          })),
+          characterName,
+          message:
+            results.length > 0
+              ? `Found ${results.length} items featuring character "${characterName}"`
+              : `No items found featuring character "${characterName}"`,
         };
       },
     }),

--- a/apps/nextjs-app/lib/db/item-people-search.ts
+++ b/apps/nextjs-app/lib/db/item-people-search.ts
@@ -1,0 +1,156 @@
+import { db, itemPeople, items, people } from "@streamystats/database";
+import type { Item } from "@streamystats/database/schema";
+import { and, desc, eq, ilike, inArray, isNull } from "drizzle-orm";
+
+export interface ItemPeopleSearchCredit {
+  personId: string;
+  personName: string;
+  creditType: string;
+  characterName: string | null;
+}
+
+interface ItemPeopleSearchRow extends ItemPeopleSearchCredit {
+  item: Item;
+}
+
+export interface ItemPeopleSearchResult {
+  item: Item;
+  credits: ItemPeopleSearchCredit[];
+}
+
+export function collapseItemPeopleMatches(
+  rows: ItemPeopleSearchRow[],
+  limit: number,
+): ItemPeopleSearchResult[] {
+  const resultsByItemId = new Map<string, ItemPeopleSearchResult>();
+
+  for (const row of rows) {
+    const credit = {
+      personId: row.personId,
+      personName: row.personName,
+      creditType: row.creditType,
+      characterName: row.characterName,
+    };
+    const existing = resultsByItemId.get(row.item.id);
+
+    if (existing) {
+      existing.credits.push(credit);
+    } else {
+      resultsByItemId.set(row.item.id, {
+        item: row.item,
+        credits: [credit],
+      });
+    }
+  }
+
+  return [...resultsByItemId.values()].slice(0, limit);
+}
+
+type SearchItemType = "Movie" | "Series" | "all";
+
+function getExpandedRowLimit(limit: number): number {
+  return limit * 4;
+}
+
+export async function findItemsByPerson({
+  serverId,
+  personName,
+  creditType,
+  type,
+  limit,
+}: {
+  serverId: number;
+  personName: string;
+  creditType: "Actor" | "Director" | "Writer" | "Producer" | "all";
+  type: SearchItemType;
+  limit: number;
+}): Promise<ItemPeopleSearchResult[]> {
+  const conditions = [
+    eq(itemPeople.serverId, serverId),
+    eq(people.serverId, serverId),
+    eq(items.serverId, serverId),
+    ilike(people.name, `%${personName}%`),
+    isNull(items.deletedAt),
+  ];
+
+  if (creditType !== "all") {
+    conditions.push(eq(itemPeople.type, creditType));
+  }
+  if (type !== "all") {
+    conditions.push(eq(items.type, type));
+  } else {
+    conditions.push(inArray(items.type, ["Movie", "Series"]));
+  }
+
+  const rows = await db
+    .select({
+      item: items,
+      personId: people.id,
+      personName: people.name,
+      creditType: itemPeople.type,
+      characterName: itemPeople.role,
+    })
+    .from(itemPeople)
+    .innerJoin(
+      people,
+      and(
+        eq(itemPeople.personId, people.id),
+        eq(itemPeople.serverId, people.serverId),
+      ),
+    )
+    .innerJoin(items, eq(itemPeople.itemId, items.id))
+    .where(and(...conditions))
+    .orderBy(desc(items.communityRating), items.name, itemPeople.sortOrder)
+    .limit(getExpandedRowLimit(limit));
+
+  return collapseItemPeopleMatches(rows, limit);
+}
+
+export async function findItemsByCharacter({
+  serverId,
+  characterName,
+  type,
+  limit,
+}: {
+  serverId: number;
+  characterName: string;
+  type: SearchItemType;
+  limit: number;
+}): Promise<ItemPeopleSearchResult[]> {
+  const conditions = [
+    eq(itemPeople.serverId, serverId),
+    eq(itemPeople.type, "Actor"),
+    eq(items.serverId, serverId),
+    ilike(itemPeople.role, `%${characterName}%`),
+    isNull(items.deletedAt),
+  ];
+
+  if (type !== "all") {
+    conditions.push(eq(items.type, type));
+  } else {
+    conditions.push(inArray(items.type, ["Movie", "Series"]));
+  }
+
+  const rows = await db
+    .select({
+      item: items,
+      personId: people.id,
+      personName: people.name,
+      creditType: itemPeople.type,
+      characterName: itemPeople.role,
+    })
+    .from(itemPeople)
+    .innerJoin(
+      people,
+      and(
+        eq(itemPeople.personId, people.id),
+        eq(itemPeople.serverId, people.serverId),
+      ),
+    )
+    .innerJoin(items, eq(itemPeople.itemId, items.id))
+    .where(and(...conditions))
+    .orderBy(desc(items.communityRating), items.name, itemPeople.sortOrder)
+    .limit(getExpandedRowLimit(limit));
+
+  return collapseItemPeopleMatches(rows, limit);
+}

--- a/apps/nextjs-app/lib/db/item-people-search.ts
+++ b/apps/nextjs-app/lib/db/item-people-search.ts
@@ -1,6 +1,6 @@
 import { db, itemPeople, items, people } from "@streamystats/database";
 import type { Item } from "@streamystats/database/schema";
-import { and, desc, eq, ilike, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, isNull, or } from "drizzle-orm";
 
 export interface ItemPeopleSearchCredit {
   personId: string;
@@ -20,6 +20,7 @@ export interface ItemPeopleSearchResult {
 
 export function collapseItemPeopleMatches(
   rows: ItemPeopleSearchRow[],
+  requiredPersonNames: string[],
   limit: number,
 ): ItemPeopleSearchResult[] {
   const resultsByItemId = new Map<string, ItemPeopleSearchResult>();
@@ -43,7 +44,19 @@ export function collapseItemPeopleMatches(
     }
   }
 
-  return [...resultsByItemId.values()].slice(0, limit);
+  const normalizedNames = requiredPersonNames.map((name) =>
+    name.trim().toLowerCase(),
+  );
+
+  return [...resultsByItemId.values()]
+    .filter(({ credits }) =>
+      normalizedNames.every((name) =>
+        credits.some((credit) =>
+          credit.personName.toLowerCase().includes(name),
+        ),
+      ),
+    )
+    .slice(0, limit);
 }
 
 type SearchItemType = "Movie" | "Series" | "all";
@@ -54,22 +67,30 @@ function getExpandedRowLimit(limit: number): number {
 
 export async function findItemsByPerson({
   serverId,
-  personName,
+  personNames,
   creditType,
   type,
   limit,
 }: {
   serverId: number;
-  personName: string;
+  personNames: string[];
   creditType: "Actor" | "Director" | "Writer" | "Producer" | "all";
   type: SearchItemType;
   limit: number;
 }): Promise<ItemPeopleSearchResult[]> {
+  const normalizedNames = personNames
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  if (normalizedNames.length === 0) {
+    return [];
+  }
+
   const conditions = [
     eq(itemPeople.serverId, serverId),
     eq(people.serverId, serverId),
     eq(items.serverId, serverId),
-    ilike(people.name, `%${personName}%`),
+    or(...normalizedNames.map((name) => ilike(people.name, `%${name}%`))),
     isNull(items.deletedAt),
   ];
 
@@ -100,10 +121,9 @@ export async function findItemsByPerson({
     )
     .innerJoin(items, eq(itemPeople.itemId, items.id))
     .where(and(...conditions))
-    .orderBy(desc(items.communityRating), items.name, itemPeople.sortOrder)
-    .limit(getExpandedRowLimit(limit));
+    .orderBy(desc(items.communityRating), items.name, itemPeople.sortOrder);
 
-  return collapseItemPeopleMatches(rows, limit);
+  return collapseItemPeopleMatches(rows, normalizedNames, limit);
 }
 
 export async function findItemsByCharacter({
@@ -152,5 +172,5 @@ export async function findItemsByCharacter({
     .orderBy(desc(items.communityRating), items.name, itemPeople.sortOrder)
     .limit(getExpandedRowLimit(limit));
 
-  return collapseItemPeopleMatches(rows, limit);
+  return collapseItemPeopleMatches(rows, [], limit);
 }


### PR DESCRIPTION
## Search by people/character

Implement new AI tools to allow searching for media content based on:
- People (actors, directors, writers, producers)
- Fictional characters

This includes new database utility functions in `item-people-search.ts` to query items via person names or character roles, and the integration of these functions into the chat toolset.

## Screenshot:

<img width="1151" height="872" alt="image" src="https://github.com/user-attachments/assets/35f8d260-567f-4ad7-9bfd-7d4fe80f381a" />

## Summary by Sourcery

Add AI chat tools and database queries to search movies and series by people and fictional characters.

New Features:
- Introduce an AI tool to find media items related to a person with optional filters for credit type and media type.
- Introduce an AI tool to find media items by fictional character name, returning matching roles and actors.

Enhancements:
- Add database utilities to query and aggregate movies and series by associated people or character roles for AI-driven search.