### PR TITLE
fix: use internal url for all server-to-server jellyfin communication

### DIFF
--- a/apps/job-server/src/jellyfin/sync/people.ts
+++ b/apps/job-server/src/jellyfin/sync/people.ts
@@ -273,7 +273,12 @@ async function createClientForServerId(
   serverId: number
 ): Promise<{ client: JellyfinClient; serverName: string }> {
   const serverRows = await db
-    .select({ url: servers.url, apiKey: servers.apiKey, name: servers.name })
+    .select({
+      url: servers.url,
+      internalUrl: servers.internalUrl,
+      apiKey: servers.apiKey,
+      name: servers.name,
+    })
     .from(servers)
     .where(eq(servers.id, serverId))
     .limit(1);

--- a/apps/job-server/src/jobs/server-jobs.ts
+++ b/apps/job-server/src/jobs/server-jobs.ts
@@ -86,6 +86,7 @@ export async function backfillJellyfinIdsJob(job: PgBossJob<Record<string, never
         id: servers.id,
         name: servers.name,
         url: servers.url,
+        internalUrl: servers.internalUrl,
         apiKey: servers.apiKey,
       })
       .from(servers)

--- a/apps/job-server/src/routes/jobs/servers.ts
+++ b/apps/job-server/src/routes/jobs/servers.ts
@@ -198,8 +198,12 @@ app.post("/create-server", async (c) => {
       return c.json({ error: "Name, URL, and API key are required" }, 400);
     }
 
+    // Server-to-server requests use the internal URL when configured (falling back
+    // to the external URL), so test connectivity against that effective URL.
+    const effectiveUrl = otherFields.internalUrl || url;
+
     try {
-      const testResponse = await fetch(`${url}/System/Info`, {
+      const testResponse = await fetch(`${effectiveUrl}/System/Info`, {
         headers: {
           "Authorization": `MediaBrowser Client="Streamystats", Version="${STREAMYSTATS_VERSION}", Token="${apiKey}"`,
           "Content-Type": "application/json",

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/actions.ts
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/actions.ts
@@ -129,9 +129,14 @@ export async function updateConnectionSettingsAction({
       };
     }
 
-    // Test connection to new URL with the API key
+    // Server-to-server requests use the internal URL when configured (falling back
+    // to the external URL), so validate connectivity against that effective URL.
+    // The external URL is client-facing and may be unreachable from the server.
+    const effectiveUrl = normalizedInternalUrl ?? normalizedUrl;
+
+    // Test connection with the API key against the effective (internal-preferred) URL
     try {
-      const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
+      const testResponse = await fetch(`${effectiveUrl}/System/Info`, {
         method: "GET",
         headers: jellyfinHeaders(effectiveApiKey),
         signal: AbortSignal.timeout(5000),
@@ -157,34 +162,6 @@ export async function updateConnectionSettingsAction({
         ServerName?: string;
         Version?: string;
       };
-
-      // Validate internal URL connectivity if provided
-      if (normalizedInternalUrl) {
-        try {
-          const internalResponse = await fetch(
-            `${normalizedInternalUrl}/System/Info`,
-            {
-              method: "GET",
-              headers: jellyfinHeaders(effectiveApiKey),
-              signal: AbortSignal.timeout(5000),
-            },
-          );
-
-          if (!internalResponse.ok) {
-            return {
-              success: false,
-              message:
-                "Internal URL is unreachable. Please check the URL and try again.",
-            };
-          }
-        } catch {
-          return {
-            success: false,
-            message:
-              "Failed to connect to internal URL. Please check the URL and try again.",
-          };
-        }
-      }
 
       const updateData: {
         url: string;

--- a/apps/nextjs-app/lib/db/server.ts
+++ b/apps/nextjs-app/lib/db/server.ts
@@ -669,10 +669,19 @@ export const updateServerConnection = async ({
 
     // Normalize URL by removing trailing slash
     const normalizedUrl = url.endsWith("/") ? url.slice(0, -1) : url;
+    const normalizedInternalUrl = internalUrl
+      ? internalUrl.endsWith("/")
+        ? internalUrl.slice(0, -1)
+        : internalUrl
+      : null;
+    // Server-to-server requests use the internal URL when configured (falling back
+    // to the external URL), so test connectivity against that effective URL — the
+    // external URL is client-facing and may be unreachable from the server.
+    const effectiveUrl = normalizedInternalUrl ?? normalizedUrl;
 
     // Test connection to new Jellyfin server with new API key
     try {
-      const testResponse = await fetch(`${normalizedUrl}/System/Info`, {
+      const testResponse = await fetch(`${effectiveUrl}/System/Info`, {
         method: "GET",
         headers: jellyfinHeaders(apiKey),
         signal: AbortSignal.timeout(5000),
@@ -719,7 +728,7 @@ export const updateServerConnection = async ({
       // Authenticate user credentials against new server.
       // Use a unique DeviceId so this doesn't revoke existing browser sessions.
       const authResponse = await fetch(
-        `${normalizedUrl}/Users/AuthenticateByName`,
+        `${effectiveUrl}/Users/AuthenticateByName`,
         {
           method: "POST",
           headers: jellyfinHeaders(apiKey, {


### PR DESCRIPTION
When an internal URL is configured for a server, it should be used for all
Streamystats → Jellyfin communication, with the external URL reserved for
client-facing links. Several server-side paths were still using the external
URL, so deployments where the external URL isn't reachable from the container
(reverse proxy / split-horizon DNS) failed.

Fixes:
- people-sync built its Jellyfin client from a query that didn't select
  `internalUrl`, so `getInternalUrl()` always fell back to the external URL.
- the `backfill-jellyfin-ids` job had the same missing-column issue.
- connection-validation requests (settings update, reconnect, initial setup)
  probed the external URL server-side. They now validate against the effective
  (internal-preferred) URL, so updating the external URL no longer requires the
  server to be able to reach it.

No schema changes.

## Summary by Sourcery

Ensure all server-to-server Jellyfin communication consistently prefers the configured internal URL, falling back to the external URL when necessary.

Bug Fixes:
- Fix people sync to build the Jellyfin client with access to the internal URL so internal-preferred routing is honored.
- Fix the backfill Jellyfin IDs job to include the internal URL when constructing Jellyfin clients.
- Fix connection validation and server creation to test connectivity against the effective (internal-preferred) Jellyfin URL instead of always using the external URL.