### PR TITLE
feat: log in with Jellyfin Quick Connect

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/login/SignInForm.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/login/SignInForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowLeft, QrCode, Smartphone } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -25,7 +26,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { login } from "@/lib/auth";
+import { initiateQuickConnect, login, verifyQuickConnect } from "@/lib/auth";
 import type { ServerPublic } from "@/lib/types";
 
 const FormSchema = z.object({
@@ -40,6 +41,7 @@ interface Props {
 
 export const SignInForm: React.FC<Props> = ({ server, servers }) => {
   const [loading, setLoading] = useState(false);
+  const [quickConnect, setQuickConnect] = useState<boolean>(false);
   const router = useRouter();
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -70,65 +72,94 @@ export const SignInForm: React.FC<Props> = ({ server, servers }) => {
 
   return (
     <div className="flex h-screen w-full items-center justify-center px-4">
-      <Card className="mx-auto lg:min-w-[400px]">
+      <Card className="mx-auto w-full max-w-md lg:min-w-[400px]">
         <CardHeader>
           <CardTitle className="text-2xl">
-            Log in to{" "}
+            {quickConnect ? "Quick Connect to " : "Log in to "}
             <span className="font-bold text-blue-500">{server.name}</span>
           </CardTitle>
           <CardDescription>
-            Log in to Streamystats by using your Jellyfin account
+            {quickConnect
+              ? "Sign in using a Quick Connect code from your Jellyfin app"
+              : "Log in to Streamystats by using your Jellyfin account"}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(onSubmit)}
-              className="w-full space-y-6"
-            >
-              <FormField
-                control={form.control}
-                name="username"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Username</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="John"
-                        {...field}
-                        autoComplete="username"
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      Enter your Jellyfin username
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="**********"
-                        {...field}
-                        autoComplete="current-password"
-                      />
-                    </FormControl>
-                    <FormDescription>Jellyfin password</FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+          {quickConnect ? (
+            <QuickConnectSignIn
+              serverId={server.id}
+              onBack={() => setQuickConnect(false)}
+            />
+          ) : (
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="w-full space-y-6"
+              >
+                <FormField
+                  control={form.control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Username</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="John"
+                          {...field}
+                          autoComplete="username"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Enter your Jellyfin username
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="**********"
+                          {...field}
+                          autoComplete="current-password"
+                        />
+                      </FormControl>
+                      <FormDescription>Jellyfin password</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? <Spinner /> : "Sign In"}
+                </Button>
+              </form>
 
-              <Button type="submit">{loading ? <Spinner /> : "Sign In"}</Button>
-            </form>
-          </Form>
+              <div className="my-6 flex items-center">
+                <div className="h-px flex-1 bg-border" />
+                <span className="px-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  Or
+                </span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                className="flex w-full items-center justify-center gap-2"
+                onClick={() => setQuickConnect(true)}
+              >
+                <QrCode className="size-4 text-blue-500" />
+                <span>Log in with Quick Connect</span>
+              </Button>
+            </Form>
+          )}
+
           {/* Only show this section if there are other servers available */}
           {servers.filter((s) => s.id !== server.id).length > 0 && (
             <div className="mt-6 space-y-4">
@@ -166,3 +197,135 @@ export const SignInForm: React.FC<Props> = ({ server, servers }) => {
     </div>
   );
 };
+
+export function QuickConnectSignIn({
+  serverId,
+  onBack,
+}: {
+  serverId: number;
+  onBack: () => void;
+}) {
+  const router = useRouter();
+  const [qcData, setQcData] = useState<{
+    code: string;
+    secret: string;
+    device: { id: string; name: string };
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // 1. Initiate Quick Connect when modal opens
+  useEffect(() => {
+    initiateQuickConnect({
+      serverId,
+      userAgent: navigator.userAgent,
+    })
+      .then(setQcData)
+      .catch((err) => {
+        const message =
+          err instanceof Error ? err.message : "Error initiating Quick Connect";
+        setError(message);
+        toast.error(message);
+        console.error("Error initiating Quick Connect:", err);
+      });
+  }, [serverId]);
+
+  // 2. Poll the server every 3 seconds once we have a secret
+  useEffect(() => {
+    if (!qcData) return;
+
+    const interval = setInterval(async () => {
+      try {
+        const result = await verifyQuickConnect({
+          serverId,
+          secret: qcData.secret,
+          device: qcData.device,
+        });
+
+        if (result.authenticated) {
+          clearInterval(interval);
+          toast.success("Logged in successfully");
+          router.push(`/servers/${serverId}/dashboard`);
+        }
+      } catch (err) {
+        console.error("Polling error:", err);
+      }
+    }, 3000);
+
+    // Cleanup interval if user closes modal or navigates away
+    return () => clearInterval(interval);
+  }, [qcData, serverId, router]);
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+            <p className="text-sm font-medium text-destructive">{error}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Make sure Quick Connect is enabled in your Jellyfin server
+              settings under Dashboard → General → Quick Connect.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={onBack}
+          >
+            <ArrowLeft className="mr-2 size-4" />
+            Back to Password Login
+          </Button>
+        </div>
+      ) : !qcData ? (
+        <div className="flex flex-col items-center justify-center py-8 space-y-3">
+          <Spinner />
+          <p className="text-sm text-muted-foreground">
+            Generating Quick Connect code...
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="relative flex flex-col items-center justify-center rounded-xl border border-border bg-card/60 px-6 py-8 text-center shadow-inner">
+            <div className="font-mono text-4xl font-extrabold tracking-[0.3em] text-foreground sm:text-5xl">
+              {qcData.code}
+            </div>
+            <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="relative flex size-2">
+                <span className="absolute inline-flex size-full animate-ping rounded-full bg-blue-400 opacity-75" />
+                <span className="relative inline-flex size-2 rounded-full bg-blue-500" />
+              </span>
+              Waiting for authorization...
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-muted/30 p-4 space-y-2.5 text-xs text-muted-foreground">
+            <div className="font-medium text-foreground flex items-center gap-1.5">
+              <Smartphone className="size-3.5 text-blue-400" />
+              <span>How to connect:</span>
+            </div>
+            <ol className="list-decimal list-inside space-y-1.5 pl-1">
+              <li>Open Jellyfin on your TV, mobile device, or browser</li>
+              <li>
+                Go to{" "}
+                <span className="font-medium text-foreground">
+                  User Menu → Quick Connect
+                </span>
+              </li>
+              <li>Enter the 6-character code shown above</li>
+            </ol>
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={onBack}
+          >
+            <ArrowLeft className="mr-2 size-4" />
+            Back to Password Login
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/nextjs-app/lib/auth.ts
+++ b/apps/nextjs-app/lib/auth.ts
@@ -50,6 +50,10 @@ export const login = async ({
 
   const data = await res.json();
 
+  await setToken(data, serverId);
+};
+
+async function setToken(data: any, serverId: number) {
   const accessToken = data.AccessToken;
   const user = data.User;
   const isAdmin = user.Policy.IsAdministrator;
@@ -74,4 +78,79 @@ export const login = async ({
     maxAge,
     secure,
   });
+}
+
+// function to request a quickconnect code using a simple post request and return it to a client
+export const initiateQuickConnect = async ({
+  serverId,
+  userAgent,
+}: {
+  serverId: number;
+  userAgent: string;
+}) => {
+  const server = await getServerWithSecrets({ serverId: serverId.toString() });
+  if (!server) {
+    throw new Error("Server not found");
+  }
+
+  const device = {
+    id: crypto.randomUUID(),
+    name: userAgent ? parseDeviceName(userAgent) : "Streamystats Web",
+  };
+
+  const res = await fetch(`${getInternalUrl(server)}/QuickConnect/Initiate`, {
+    method: "POST",
+    headers: jellyfinHeaders(server.apiKey, device),
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      "Failed to generate Quick Connect code. Maybe it's disabled on this server?",
+    );
+  }
+
+  const decoded = await res.json();
+
+  // Return the secret and device info to the client so it can poll using verifyQuickConnect
+  return {
+    code: decoded.Code,
+    secret: decoded.Secret,
+    device,
+  };
+};
+// function that the client polls every 3 seconds to check the status of the code
+export const verifyQuickConnect = async ({
+  serverId,
+  secret,
+  device,
+}: {
+  serverId: number;
+  secret: string;
+  device: { id: string; name: string };
+}) => {
+  const server = await getServerWithSecrets({ serverId: serverId.toString() });
+  if (!server) {
+    throw new Error("Server not found");
+  }
+
+  // try to get token
+  const res = await fetch(
+    `${getInternalUrl(server)}/Users/AuthenticateWithQuickConnect`,
+    {
+      method: "POST",
+      headers: jellyfinHeaders(server.apiKey, device),
+      body: JSON.stringify({ Secret: secret }),
+    },
+  );
+
+  // 200 = login succeeded, anything else = nothing yet
+  if (res.status === 200) {
+    const decoded = await res.json();
+
+    // return to client
+    await setToken(decoded, serverId);
+    return { authenticated: true };
+  }
+
+  return { authenticated: false };
 };


### PR DESCRIPTION
This PR adds support for logging in with Jellyfin Quick Connect codes. This makes the project usable in environments where the login process may not use Jellyfin's internal user DB (such as the jellyfin-plugin-sso project which allows OAuth2 login). I'm planning on implementing a switch to disable this and/or username/password login in the near future as well.

Please check the UI before merging, as it was made with AI, and might not fit the rest of the project (although I checked it and it seemed fine to me, but I don't have a great eye for frontend things).

Here's a screenshot of the new GUI element:
<img width="502" height="544" alt="Screenshot 2026-07-09 at 21 26 09" src="https://github.com/user-attachments/assets/3c1c9920-a8c0-4937-b7b5-f3a09aa6c2cd" />

Thank you!

## Summary by Sourcery

Add Jellyfin Quick Connect as an alternative login method alongside existing username/password authentication.

New Features:
- Introduce a Quick Connect login flow that initiates a code, polls for authorization, and logs users into the selected Jellyfin server.
- Add a dedicated QuickConnectSignIn UI with guidance and error handling for connecting via Jellyfin apps.

Enhancements:
- Refactor token handling into a reusable setToken helper used by both standard and Quick Connect authentication flows.