### PR TITLE
fix: specify user and database in AIO postgres healthcheck

### DIFF
--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -133,6 +133,6 @@ EXPOSE 3000
 VOLUME /var/lib/postgresql/data
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
-  CMD curl -f http://127.0.0.1:3000/api/health && curl -f http://127.0.0.1:3005/health && pg_isready -h localhost || exit 1
+  CMD curl -f http://127.0.0.1:3000/api/health && curl -f http://127.0.0.1:3005/health && pg_isready -h localhost -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-streamystats}" || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
Fixes #367.

`pg_isready` in the AIO healthcheck runs without `-U`/`-d`, so libpq falls back to the container's OS user (`root`). PostgreSQL rejects the connection and logs `FATAL: role "root" does not exist` every 30s, matching the healthcheck interval.

The check itself still passes (the server responds), so this is log noise rather than a functional failure, but it floods the logs and obscures real errors.

Uses the image's existing `POSTGRES_USER` / `POSTGRES_DB` env vars so user overrides are respected.

## Summary by Sourcery

Specify the Postgres user and database for the AIO container healthcheck to avoid spurious connection errors in logs.

Bug Fixes:
- Prevent AIO Postgres healthcheck from connecting as the OS root user and generating FATAL role errors in the server logs.

Build:
- Update Dockerfile.aio healthcheck command to use POSTGRES_USER and POSTGRES_DB environment variables for pg_isready.