### PR TITLE
fix: allow postgres to shut down cleanly in AIO container

### DIFF
--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -46,6 +46,10 @@ services:
     volumes:
       - streamystats_data:/var/lib/postgresql/data
     restart: unless-stopped
+    # Docker's default 10s stop timeout is not enough for postgres to shut down
+    # cleanly, which forces WAL recovery on the next start. This is an upper
+    # bound, not a fixed delay.
+    stop_grace_period: 60s
     logging:
       driver: json-file
       options:

--- a/docker/aio/supervisord.conf
+++ b/docker/aio/supervisord.conf
@@ -15,9 +15,11 @@ priority=10
 ; PostgreSQL reads SIGTERM as a "smart" shutdown: it waits for every client to
 ; disconnect first, which never happens while job-server and nextjs are still
 ; draining. SIGINT requests a fast shutdown instead, so postgres exits cleanly
-; before the stop timeout expires and forces a SIGKILL.
+; before the stop timeout expires and forces a SIGKILL. stopwaitsecs stays just
+; under the container's stop_grace_period so a slow fast-shutdown under load is
+; not cut short by supervisord before docker would have given up.
 stopsignal=INT
-stopwaitsecs=30
+stopwaitsecs=55
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/docker/aio/supervisord.conf
+++ b/docker/aio/supervisord.conf
@@ -12,6 +12,12 @@ environment=POSTGRES_USER="%(ENV_POSTGRES_USER)s",POSTGRES_PASSWORD="%(ENV_POSTG
 autostart=true
 autorestart=true
 priority=10
+; PostgreSQL reads SIGTERM as a "smart" shutdown: it waits for every client to
+; disconnect first, which never happens while job-server and nextjs are still
+; draining. SIGINT requests a fast shutdown instead, so postgres exits cleanly
+; before the stop timeout expires and forces a SIGKILL.
+stopsignal=INT
+stopwaitsecs=30
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Stopping the AIO container leaves PostgreSQL unclean, so every start runs WAL recovery:

```
WARN received SIGINT indicating exit request
INFO waiting for postgres, job-server, nextjs to die
INFO waiting for postgres, job-server, nextjs to die
[AIO] Starting Streamystats All-in-One...
LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  redo starts at 0/15DCAA28
```

supervisord sends SIGTERM, which PostgreSQL treats as a *smart* shutdown: it waits for every client to disconnect before exiting. job-server still holds pool and session-poller connections while it drains, so postgres never finishes and docker SIGKILLs the container once the stop timeout expires.

`stopsignal=INT` requests a fast shutdown instead, so postgres disconnects clients and exits cleanly. `stop_grace_period` raises docker's 10s default as a safety margin for larger databases; `docker run` users can pass `--stop-timeout=60`.

Recovery has been succeeding, so there is no known data loss, but the container currently depends on crash recovery for every restart.

## Summary by Sourcery

Adjust PostgreSQL shutdown behavior in the AIO container to ensure clean exits and avoid WAL crash recovery on restart.

Enhancements:
- Configure supervisord to send SIGINT and extend the wait time so PostgreSQL can perform a fast, clean shutdown before the container is killed.

Deployment:
- Increase the Docker stop grace period for the AIO service to give PostgreSQL sufficient time to shut down cleanly.