### PR TITLE
feat: add UTC timestamps to job-server log lines

### DIFF
--- a/apps/job-server/src/jellyfin/sync/sync-log.ts
+++ b/apps/job-server/src/jellyfin/sync/sync-log.ts
@@ -32,7 +32,7 @@ function formatValue(value: SyncLogExtraValue): string {
 }
 
 export function formatSyncLogLine(prefix: string, fields: SyncLogFields): string {
-  const parts: string[] = [`[${prefix}]`];
+  const parts: string[] = [new Date().toISOString(), `[${prefix}]`];
 
   for (const key of BASE_KEY_ORDER) {
     parts.push(`${key}=${formatValue(fields[key])}`);

--- a/apps/job-server/src/jellyfin/sync/sync-log.ts
+++ b/apps/job-server/src/jellyfin/sync/sync-log.ts
@@ -1,3 +1,5 @@
+import { formatLogTimestamp } from "../../utils/log-timestamp";
+
 type SyncLogBaseFields = {
   server: string;
   page: number;
@@ -32,7 +34,7 @@ function formatValue(value: SyncLogExtraValue): string {
 }
 
 export function formatSyncLogLine(prefix: string, fields: SyncLogFields): string {
-  const parts: string[] = [new Date().toISOString(), `[${prefix}]`];
+  const parts: string[] = [formatLogTimestamp(), `[${prefix}]`];
 
   for (const key of BASE_KEY_ORDER) {
     parts.push(`${key}=${formatValue(fields[key])}`);

--- a/apps/job-server/src/utils/log-timestamp.ts
+++ b/apps/job-server/src/utils/log-timestamp.ts
@@ -1,0 +1,10 @@
+/**
+ * Timestamp prefix shared by the job server's log formatters.
+ *
+ * ISO 8601 UTC keeps log lines sortable and unambiguous, and matches the
+ * convention that all data is stored in UTC. Keeping it here means the format
+ * only has to change in one place.
+ */
+export function formatLogTimestamp(): string {
+  return new Date().toISOString();
+}

--- a/apps/job-server/src/utils/structured-log.ts
+++ b/apps/job-server/src/utils/structured-log.ts
@@ -1,10 +1,12 @@
+import { formatLogTimestamp } from "./log-timestamp";
+
 type LogValue = string | number | boolean | null | undefined;
 
 export function structuredLog(
   prefix: string,
   data: Record<string, LogValue>
 ): void {
-  const parts = [new Date().toISOString(), `[${prefix}]`];
+  const parts = [formatLogTimestamp(), `[${prefix}]`];
   for (const [key, value] of Object.entries(data)) {
     if (value !== undefined && value !== null) {
       parts.push(`${key}=${value}`);

--- a/apps/job-server/src/utils/structured-log.ts
+++ b/apps/job-server/src/utils/structured-log.ts
@@ -4,7 +4,7 @@ export function structuredLog(
   prefix: string,
   data: Record<string, LogValue>
 ): void {
-  const parts = [`[${prefix}]`];
+  const parts = [new Date().toISOString(), `[${prefix}]`];
   for (const [key, value] of Object.entries(data)) {
     if (value !== undefined && value !== null) {
       parts.push(`${key}=${value}`);


### PR DESCRIPTION
Job server log lines carry no timestamp, so there is no way to tell when a sync ran, how long a gap between jobs was, or how job output lines up with the PostgreSQL lines interleaved in the same `docker logs` stream (those already carry timestamps).

Before:

```
[recent-items-sync] server=jellyfin_unraid page=7 processed=100 inserted=0 updated=0 errors=0 ...
```

After:

```
2026-07-25T00:19:28.869Z [recent-items-sync] server=jellyfin_unraid page=7 processed=100 inserted=0 updated=0 errors=0 ...
```

ISO 8601 UTC keeps lines sortable and unambiguous, and matches the convention that all data is stored in UTC. It needs no configuration and works from the first line logged, before any database connection exists.

Both log formatters are covered so output stays consistent: `formatSyncLogLine` (all sync jobs) and `structuredLog` (session poller, server jobs, infer-watchtime). Every `formatSyncLogLine` caller passes the result straight to `console.info`/`console.error`, so nothing that persists the string is affected.

Plain `console.log` lines elsewhere (`[scheduler]`, `[pg-boss]`) are unchanged and still have no timestamp.

## Summary by Sourcery

Add ISO 8601 UTC timestamps to structured job-server log lines for sync and utility logging.

Enhancements:
- Update sync job log formatting to prepend an ISO 8601 UTC timestamp to each line.
- Update structured logging utility to include an ISO 8601 UTC timestamp in all structured log output.