### PR TITLE
fix: keep excluded libraries visible in exclusions manager

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/ExcludedLibrariesManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/ExcludedLibrariesManager.tsx
@@ -64,7 +64,9 @@ export function ExcludedLibrariesManager({
     });
   };
 
-  const excludedCount = excludedLibraryIds.length;
+  const excludedCount = libraries.filter((library) =>
+    excludedLibraryIds.includes(library.id),
+  ).length;
 
   return (
     <Card>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/ExcludedLibrariesManager.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/ExcludedLibrariesManager.tsx
@@ -64,9 +64,13 @@ export function ExcludedLibrariesManager({
     });
   };
 
-  const excludedCount = libraries.filter((library) =>
-    excludedLibraryIds.includes(library.id),
-  ).length;
+  const excludedIdSet = new Set(excludedLibraryIds);
+  let excludedCount = 0;
+  for (const library of libraries) {
+    if (excludedIdSet.has(library.id)) {
+      excludedCount += 1;
+    }
+  }
 
   return (
     <Card>

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/page.tsx
@@ -22,7 +22,8 @@ export default async function ExclusionsSettings(props: {
 
   const [users, libraries] = await Promise.all([
     getUsers({ serverId: server.id }),
-    getLibraries({ serverId: server.id, includeExcluded: true }),
+    // Skip statistics exclusion filters so excluded libraries remain manageable
+    getLibraries({ serverId: server.id, includeStatisticsExcluded: true }),
   ]);
 
   return (

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/settings/exclusions/page.tsx
@@ -22,7 +22,7 @@ export default async function ExclusionsSettings(props: {
 
   const [users, libraries] = await Promise.all([
     getUsers({ serverId: server.id }),
-    getLibraries({ serverId: server.id }),
+    getLibraries({ serverId: server.id, includeExcluded: true }),
   ]);
 
   return (

--- a/apps/nextjs-app/lib/db/libraries.ts
+++ b/apps/nextjs-app/lib/db/libraries.ts
@@ -7,10 +7,19 @@ import { getStatisticsExclusions } from "./exclusions";
 export const getLibraries = async ({
   serverId,
   userId,
+  includeExcluded = false,
 }: {
   serverId: number;
   userId?: string;
+  /** When true, skip statistics exclusion filters (needed for the exclusions manager UI). */
+  includeExcluded?: boolean;
 }) => {
+  if (includeExcluded) {
+    return await db.query.libraries.findMany({
+      where: eq(libraries.serverId, serverId),
+    });
+  }
+
   const { librariesTableExclusion } = await getStatisticsExclusions(
     serverId,
     userId,

--- a/apps/nextjs-app/lib/db/libraries.ts
+++ b/apps/nextjs-app/lib/db/libraries.ts
@@ -7,14 +7,18 @@ import { getStatisticsExclusions } from "./exclusions";
 export const getLibraries = async ({
   serverId,
   userId,
-  includeExcluded = false,
+  includeStatisticsExcluded = false,
 }: {
   serverId: number;
   userId?: string;
-  /** When true, skip statistics exclusion filters (needed for the exclusions manager UI). */
-  includeExcluded?: boolean;
+  /**
+   * When true, skip only the library filters from `getStatisticsExclusions`
+   * (server excludedLibraryIds / user folder allowlist). Other query constraints
+   * are unchanged. Intended for the statistics exclusions manager UI.
+   */
+  includeStatisticsExcluded?: boolean;
 }) => {
-  if (includeExcluded) {
+  if (includeStatisticsExcluded) {
     return await db.query.libraries.findMany({
       where: eq(libraries.serverId, serverId),
     });


### PR DESCRIPTION
## Summary
- Fixes #553 & #510 where excluded libraries disappeared from Settings → Statistics Exclusions, making them impossible to re-enable
- The exclusions page now loads libraries with `includeExcluded: true`, matching Excluded Users behavior
- Visible/hidden counts are based on libraries actually shown in the manager

## Test plan
- Go to Settings → Statistics Exclusions
- Exclude one or more libraries, reload the page
- Confirm excluded libraries still appear in Manage Libraries with toggles off
- Re-enable them and confirm they show as visible again
- Confirm library stats still hide excluded libraries elsewhere

## Summary by Sourcery

Ensure excluded libraries remain visible and manageable in the statistics exclusions settings page.

Bug Fixes:
- Prevent excluded libraries from disappearing from the Statistics Exclusions manager, allowing them to be re-enabled.
- Correct the excluded libraries count to reflect only libraries currently shown in the manager.

Enhancements:
- Add an option to load libraries without applying statistics exclusion filters for use in the exclusions manager UI.